### PR TITLE
 Search: add Phase-1 request search migration (pg_trgm + FTS), reorganize Search docs/codes, and local validation

### DIFF
--- a/ddl/Search/codes/01_enable_fuzzy_search.sql
+++ b/ddl/Search/codes/01_enable_fuzzy_search.sql
@@ -1,0 +1,6 @@
+-- Phase 1 / Stage 1: Enable required extension for fuzzy search
+-- Safe to run multiple times
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- Optional verification query
+-- SELECT extname FROM pg_extension WHERE extname = 'pg_trgm';

--- a/ddl/Search/codes/02_add_request_search.sql
+++ b/ddl/Search/codes/02_add_request_search.sql
@@ -1,0 +1,93 @@
+-- Phase 1 / Stage 2: Request search
+-- Prerequisite: run 01_enable_fuzzy_search.sql (pg_trgm extension)
+
+-- 1) Add full-text generated column
+ALTER TABLE virginia_dev_saayam_rdbms.request
+ADD COLUMN IF NOT EXISTS search_vector tsvector
+GENERATED ALWAYS AS (
+    to_tsvector(
+        'english',
+        coalesce(req_subj, '') || ' ' ||
+        coalesce(req_desc, '') || ' ' ||
+        coalesce(req_loc, '')
+    )
+) STORED;
+
+-- 2) Create indexes for fast full-text and fuzzy matching
+CREATE INDEX IF NOT EXISTS idx_request_search_vector
+ON virginia_dev_saayam_rdbms.request USING GIN (search_vector);
+
+CREATE INDEX IF NOT EXISTS idx_request_subj_trgm
+ON virginia_dev_saayam_rdbms.request USING GIN (req_subj gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS idx_request_desc_trgm
+ON virginia_dev_saayam_rdbms.request USING GIN (req_desc gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS idx_request_loc_trgm
+ON virginia_dev_saayam_rdbms.request USING GIN (req_loc gin_trgm_ops);
+
+-- 3) Unified request search function (keyword + typo tolerance)
+CREATE OR REPLACE FUNCTION virginia_dev_saayam_rdbms.search_requests(
+    query_text TEXT,
+    limit_results INT DEFAULT 20
+)
+RETURNS TABLE (
+    req_id VARCHAR(255),
+    req_subj VARCHAR(125),
+    req_desc VARCHAR(255),
+    req_loc VARCHAR(125),
+    req_status_id INT,
+    req_priority_id INT,
+    submission_date TIMESTAMP,
+    relevance_score REAL
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF query_text IS NULL OR btrim(query_text) = '' THEN
+        RETURN;
+    END IF;
+
+    RETURN QUERY
+    WITH ranked AS (
+        SELECT
+            r.req_id,
+            r.req_subj,
+            r.req_desc,
+            r.req_loc,
+            r.req_status_id,
+            r.req_priority_id,
+            r.submission_date,
+            ts_rank_cd(
+                r.search_vector,
+                plainto_tsquery('english', query_text)
+            ) AS fts_score,
+            GREATEST(
+                similarity(coalesce(r.req_subj, ''), query_text),
+                similarity(coalesce(r.req_desc, ''), query_text),
+                similarity(coalesce(r.req_loc, ''), query_text)
+            ) AS fuzzy_score
+        FROM virginia_dev_saayam_rdbms.request r
+        WHERE
+            r.search_vector @@ plainto_tsquery('english', query_text)
+            OR coalesce(r.req_subj, '') % query_text
+            OR coalesce(r.req_desc, '') % query_text
+            OR coalesce(r.req_loc, '') % query_text
+    )
+    SELECT
+        ranked.req_id,
+        ranked.req_subj,
+        ranked.req_desc,
+        ranked.req_loc,
+        ranked.req_status_id,
+        ranked.req_priority_id,
+        ranked.submission_date,
+        (ranked.fts_score * 0.70 + ranked.fuzzy_score * 0.30)::REAL AS relevance_score
+    FROM ranked
+    ORDER BY relevance_score DESC, submission_date DESC NULLS LAST
+    LIMIT GREATEST(limit_results, 1);
+END;
+$$;
+
+-- Example usage:
+-- SELECT * FROM virginia_dev_saayam_rdbms.search_requests('emergency medical');

--- a/ddl/Search/codes/03_add_user_and_volunteer_search.sql
+++ b/ddl/Search/codes/03_add_user_and_volunteer_search.sql
@@ -1,0 +1,3 @@
+-- Phase 1 / Stage 3: User and volunteer search
+-- TODO: Add users.search_vector, volunteer skills JSONB index,
+--       and search_users(...) / search_volunteers(...) functions

--- a/ddl/Search/codes/04_add_category_and_advanced_search.sql
+++ b/ddl/Search/codes/04_add_category_and_advanced_search.sql
@@ -1,0 +1,3 @@
+-- Phase 1 / Stage 4: Category and advanced search
+-- TODO: Add help_categories.search_vector, autocomplete support,
+--       filters/highlighting, and search_logs table

--- a/ddl/Search/codes/05_enable_semantic_search_pgvector.sql
+++ b/ddl/Search/codes/05_enable_semantic_search_pgvector.sql
@@ -1,0 +1,3 @@
+-- Phase 2 / Stage 1: Enable semantic search with pgvector
+-- TODO: CREATE EXTENSION vector, add embedding columns,
+--       and create vector indexes

--- a/ddl/Search/codes/06_add_hybrid_search.sql
+++ b/ddl/Search/codes/06_add_hybrid_search.sql
@@ -1,0 +1,3 @@
+-- Phase 2 / Stage 2: Hybrid search
+-- TODO: Implement hybrid search function combining
+--       FTS + pg_trgm + pgvector signals

--- a/ddl/Search/docs/pgvector_integration_guide.md
+++ b/ddl/Search/docs/pgvector_integration_guide.md
@@ -1,0 +1,405 @@
+# pgvector Integration Guide
+
+## Seamlessly Adding Semantic Search to Existing FTS
+
+---
+
+## ✅ YES - All Three Extensions Work Together Perfectly
+
+You can combine:
+
+1. **Native FTS** - Keyword search
+2. **pg_trgm** - Fuzzy/typo tolerance
+3. **pgvector** - Semantic/AI search
+
+They're **completely independent** and can be used together or separately.
+
+---
+
+## 🔧 How They Work Together
+
+### **1. Setup (One-Time)**
+
+```sql
+-- Enable all three extensions
+CREATE EXTENSION IF NOT EXISTS pg_trgm;    -- Fuzzy matching
+CREATE EXTENSION IF NOT EXISTS vector;     -- Semantic search
+
+-- Native FTS is built into PostgreSQL, no extension needed
+```
+
+### **2. Add Columns to Your Tables**
+
+```sql
+-- Example: request table
+ALTER TABLE request
+  -- FTS column (already added in Phase 1)
+  ADD COLUMN IF NOT EXISTS search_vector tsvector
+    GENERATED ALWAYS AS (
+      to_tsvector('english',
+        coalesce(req_subj, '') || ' ' ||
+        coalesce(req_desc, '')
+      )
+    ) STORED,
+
+  -- Semantic search column (new)
+  ADD COLUMN IF NOT EXISTS search_embedding vector(1536);  -- OpenAI ada-002 size
+
+-- pg_trgm doesn't need special columns, works on existing text columns
+```
+
+### **3. Create Indexes**
+
+```sql
+-- FTS index (already created)
+CREATE INDEX IF NOT EXISTS idx_request_fts
+  ON request USING GIN(search_vector);
+
+-- Trigram indexes (already created)
+CREATE INDEX IF NOT EXISTS idx_request_subj_trgm
+  ON request USING GIN(req_subj gin_trgm_ops);
+
+-- Vector index (new)
+CREATE INDEX IF NOT EXISTS idx_request_embedding
+  ON request USING ivfflat(search_embedding vector_cosine_ops)
+  WITH (lists = 100);  -- Adjust based on data size
+```
+
+---
+
+## 🎯 Search Strategies: Use All Three
+
+### **Strategy 1: Keyword Search (FTS)**
+
+Best for: Exact terms, specific phrases
+
+```sql
+-- Find requests with "emergency" and "medical"
+SELECT req_id, req_subj, req_desc,
+       ts_rank(search_vector, query) as relevance
+FROM request,
+     to_tsquery('english', 'emergency & medical') query
+WHERE search_vector @@ query
+ORDER BY relevance DESC
+LIMIT 20;
+```
+
+**Use when:**
+
+- User searches specific keywords
+- Need fast performance (<10ms)
+- Searching 1M+ records
+
+---
+
+### **Strategy 2: Fuzzy Search (pg_trgm)**
+
+Best for: Typos, partial matches, autocomplete
+
+```sql
+-- Find similar subjects (typo-tolerant)
+-- "emergancy" finds "emergency"
+SELECT req_id, req_subj,
+       similarity(req_subj, 'emergancy') as fuzzy_score
+FROM request
+WHERE req_subj % 'emergancy'  -- % operator = similar to
+ORDER BY fuzzy_score DESC
+LIMIT 20;
+
+-- Autocomplete
+SELECT DISTINCT req_subj
+FROM request
+WHERE req_subj ILIKE 'emer%'
+ORDER BY similarity(req_subj, 'emergency') DESC
+LIMIT 10;
+```
+
+**Use when:**
+
+- Autocomplete/typeahead
+- User likely made typo
+- Searching names, titles
+
+---
+
+### **Strategy 3: Semantic Search (pgvector)**
+
+Best for: Conceptual similarity, multi-language, synonyms
+
+```sql
+-- Find semantically similar requests
+-- "heart attack" finds "cardiac arrest", "chest pain", etc.
+SELECT req_id, req_subj, req_desc,
+       1 - (search_embedding <=> $1::vector) as semantic_score
+FROM request
+WHERE search_embedding IS NOT NULL
+ORDER BY search_embedding <=> $1::vector  -- $1 = query embedding
+LIMIT 20;
+```
+
+**Use when:**
+
+- Need "smart" understanding
+- Cross-language search
+- Finding duplicates
+- Matching by concept, not exact words
+
+---
+
+### **Strategy 4: Hybrid Search (ALL THREE COMBINED)**
+
+Best for: Best overall results
+
+```sql
+-- Combine all three scores
+WITH scores AS (
+  SELECT
+    req_id,
+    req_subj,
+    req_desc,
+
+    -- Keyword score (0-1 normalized)
+    COALESCE(
+      ts_rank(search_vector, to_tsquery('english', 'emergency & medical')) /
+      (SELECT MAX(ts_rank(search_vector, to_tsquery('english', 'emergency & medical'))) FROM request WHERE search_vector @@ to_tsquery('english', 'emergency & medical')),
+      0
+    ) as keyword_score,
+
+    -- Fuzzy score (0-1)
+    COALESCE(similarity(req_subj, 'emergency medical'), 0) as fuzzy_score,
+
+    -- Semantic score (0-1)
+    COALESCE(1 - (search_embedding <=> $1::vector), 0) as semantic_score
+
+  FROM request
+  WHERE
+    search_vector @@ to_tsquery('english', 'emergency & medical')
+    OR req_subj % 'emergency medical'
+    OR (search_embedding IS NOT NULL AND search_embedding <=> $1::vector < 0.5)
+)
+SELECT
+  req_id,
+  req_subj,
+  req_desc,
+  -- Weighted combined score
+  (keyword_score * 0.5 + fuzzy_score * 0.2 + semantic_score * 0.3) as final_score
+FROM scores
+ORDER BY final_score DESC
+LIMIT 20;
+```
+
+**Weighting suggestions:**
+
+- **Keyword-heavy:** 60% keyword, 20% fuzzy, 20% semantic
+- **Balanced:** 40% keyword, 20% fuzzy, 40% semantic
+- **Semantic-heavy:** 20% keyword, 10% fuzzy, 70% semantic
+
+---
+
+## 📊 When to Use Each
+
+| Search Type        | Use FTS | Use pg_trgm | Use pgvector | Example Query                        |
+| ------------------ | ------- | ----------- | ------------ | ------------------------------------ |
+| **Exact keywords** | ✅      | ❌          | ❌           | "emergency medical help"             |
+| **Typos**          | ❌      | ✅          | ⚠️           | "emergancy help" → "emergency help"  |
+| **Autocomplete**   | ❌      | ✅          | ❌           | "emer..." → "emergency"              |
+| **Partial match**  | ❌      | ✅          | ❌           | "hann" → "johannesburg"              |
+| **Synonyms**       | ❌      | ❌          | ✅           | "doctor" → "physician"               |
+| **Cross-language** | ⚠️      | ❌          | ✅           | Search "help" → find "मदद" (Hindi)   |
+| **Conceptual**     | ❌      | ❌          | ✅           | "lonely" → "depression", "isolation" |
+| **Phrase search**  | ✅      | ❌          | ❌           | "need urgent help"                   |
+| **Multi-field**    | ✅      | ⚠️          | ✅           | Search across title + description    |
+
+---
+
+## 💰 Cost of Adding pgvector
+
+### **Embedding Generation**
+
+**Option 1: OpenAI API**
+
+- Model: text-embedding-ada-002
+- Cost: $0.0001 per 1K tokens (~750 words)
+- Quality: Excellent
+- Languages: 100+
+
+**Example cost calculation:**
+
+```
+1,000 requests × 100 words each = 133,333 tokens
+Cost = $0.0001 × 133.333 = $0.013 (one-time)
+
+Daily updates: 100 requests/day × 100 words = 4,000 tokens/day
+Cost = $0.0001 × 4 = $0.0004/day = $0.12/month
+```
+
+**Option 2: Self-hosted (sentence-transformers)**
+
+- Model: all-MiniLM-L6-v2 or multilingual-e5
+- Cost: EC2 instance ($50-100/month) OR Lambda ($5-10/month)
+- Quality: Good
+- Languages: 50+
+
+**Recommended:** Start with OpenAI (~$5-20/month), migrate to self-hosted if costs grow
+
+---
+
+## 🚀 Implementation Timeline
+
+### **Phase 1: FTS + pg_trgm (Already doing this)**
+
+- Week 1-2: Core search
+- Cost: $0
+- Covers: 90% of needs
+
+### **Phase 2: Add pgvector (Later, when needed)**
+
+- Week 3: Enable extension
+- Week 4: Generate embeddings for existing data
+- Week 5: Update API to use hybrid search
+- Cost: $5-50/month
+- Covers: 99% of needs
+
+### **Phase 3: External search (Much later, if needed)**
+
+- Timeline: 2-4 years
+- Cost: $200-500/month
+- Covers: Advanced features
+
+---
+
+## 🔧 Hybrid Search Function (Complete Example)
+
+```sql
+-- Create a stored function for hybrid search
+CREATE OR REPLACE FUNCTION search_requests_hybrid(
+  query_text TEXT,
+  query_embedding vector(1536) DEFAULT NULL,
+  limit_results INT DEFAULT 20,
+  keyword_weight FLOAT DEFAULT 0.5,
+  fuzzy_weight FLOAT DEFAULT 0.2,
+  semantic_weight FLOAT DEFAULT 0.3
+)
+RETURNS TABLE (
+  req_id VARCHAR,
+  req_subj VARCHAR,
+  req_desc VARCHAR,
+  keyword_score FLOAT,
+  fuzzy_score FLOAT,
+  semantic_score FLOAT,
+  final_score FLOAT
+) AS $$
+BEGIN
+  RETURN QUERY
+  WITH scores AS (
+    SELECT
+      r.req_id,
+      r.req_subj,
+      r.req_desc,
+
+      -- Normalize keyword score
+      CASE
+        WHEN r.search_vector @@ to_tsquery('english', query_text)
+        THEN ts_rank(r.search_vector, to_tsquery('english', query_text))
+        ELSE 0
+      END as kw_score,
+
+      -- Fuzzy similarity
+      similarity(r.req_subj || ' ' || r.req_desc, query_text) as fz_score,
+
+      -- Semantic similarity (if embedding provided)
+      CASE
+        WHEN query_embedding IS NOT NULL AND r.search_embedding IS NOT NULL
+        THEN 1 - (r.search_embedding <=> query_embedding)
+        ELSE 0
+      END as sem_score
+
+    FROM request r
+    WHERE
+      r.search_vector @@ to_tsquery('english', query_text)
+      OR (r.req_subj || ' ' || r.req_desc) % query_text
+      OR (query_embedding IS NOT NULL
+          AND r.search_embedding IS NOT NULL
+          AND r.search_embedding <=> query_embedding < 0.7)
+  )
+  SELECT
+    s.req_id,
+    s.req_subj,
+    s.req_desc,
+    s.kw_score as keyword_score,
+    s.fz_score as fuzzy_score,
+    s.sem_score as semantic_score,
+    (s.kw_score * keyword_weight +
+     s.fz_score * fuzzy_weight +
+     s.sem_score * semantic_weight) as final_score
+  FROM scores s
+  ORDER BY final_score DESC
+  LIMIT limit_results;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Usage examples:
+
+-- 1. Keyword + Fuzzy only (no embeddings)
+SELECT * FROM search_requests_hybrid('emergency medical help');
+
+-- 2. Full hybrid search (with embeddings)
+SELECT * FROM search_requests_hybrid(
+  'heart attack',
+  '[0.123, -0.456, ...]'::vector(1536),  -- Query embedding from OpenAI
+  20,
+  0.4,  -- 40% keyword weight
+  0.2,  -- 20% fuzzy weight
+  0.4   -- 40% semantic weight
+);
+
+-- 3. Heavily semantic
+SELECT * FROM search_requests_hybrid(
+  'feeling alone',
+  get_embedding('feeling alone'),
+  10,
+  0.1,  -- 10% keyword
+  0.1,  -- 10% fuzzy
+  0.8   -- 80% semantic (finds "depression", "isolation", etc.)
+);
+```
+
+---
+
+## ✅ Summary
+
+### **All Three Extensions Are Compatible**
+
+- ✅ No conflicts
+- ✅ Can use together or separately
+- ✅ Each has different strengths
+- ✅ Combine for best results
+
+### **Recommended Approach**
+
+1. **Start:** FTS + pg_trgm (Phases 1-5)
+2. **Add later:** pgvector when you need semantic search (Phase 6)
+3. **Combine:** Use hybrid search for best overall results
+
+### **Cost**
+
+- FTS + pg_trgm: $0/month
+- - pgvector: $5-50/month
+- Total: Still far cheaper than external search services ($200-500/month)
+
+### **Performance**
+
+- FTS: <10ms for millions of records
+- pg_trgm: <50ms for fuzzy searches
+- pgvector: <100ms for semantic searches
+- All three combined: <150ms
+
+### **When to Add pgvector**
+
+- ✅ Need cross-language search
+- ✅ Want synonym matching
+- ✅ Finding duplicate requests
+- ✅ Smart volunteer matching
+- ✅ After Phases 1-5 are complete
+
+**Don't add until you need it** - FTS + pg_trgm covers 90-95% of use cases.

--- a/ddl/Search/docs/search_implementation_plan.md
+++ b/ddl/Search/docs/search_implementation_plan.md
@@ -1,0 +1,770 @@
+# Saayam Search Implementation Plan
+
+## Overview
+
+This document outlines our finalized two-phase approach to implementing comprehensive search capabilities for the Saayam platform using PostgreSQL native features.
+
+---
+
+## Table of Contents
+
+- [Phase 1: Full-Text Search (FTS) + pg_trgm](#phase-1-full-text-search-fts--pg_trgm)
+  - [What We're Implementing](#what-were-implementing)
+  - [Why This Approach](#why-this-approach)
+  - [Phase 1: Implementation Checklist](#phase-1-implementation-checklist)
+    - [Stage 1: Setup & Foundation](#stage-1-setup--foundation)
+    - [Stage 2: Request Search Implementation](#stage-2-request-search-implementation)
+    - [Stage 3: User & Volunteer Search](#stage-3-user--volunteer-search)
+    - [Stage 4: Categories & Advanced Features](#stage-4-categories--advanced-features)
+    - [Stage 5: Testing & Optimization](#stage-5-testing--optimization)
+  - [Phase 1: Expected Outcomes](#phase-1-expected-outcomes)
+- [Phase 2: Semantic Search with pgvector](#phase-2-semantic-search-with-pgvector)
+  - [What Is Semantic Search?](#what-is-semantic-search)
+  - [Why Add pgvector?](#why-add-pgvector)
+  - [How pgvector Works](#how-pgvector-works)
+  - [Phase 2: Implementation Checklist](#phase-2-implementation-checklist)
+    - [Stage 1: pgvector Setup](#stage-1-pgvector-setup)
+    - [Stage 2: Hybrid Search Implementation](#stage-2-hybrid-search-implementation)
+    - [Stage 3: Testing & Integration](#stage-3-testing--integration)
+  - [Phase 2: Expected Outcomes](#phase-2-expected-outcomes)
+- [Success Metrics & Monitoring](#success-metrics--monitoring)
+- [Quick Start Guide](#quick-start-guide)
+- [Resources & Documentation](#resources--documentation)
+- [Implementation Summary](#implementation-summary)
+
+---
+
+## Phase 1: Full-Text Search (FTS) + pg_trgm
+
+**Status:** Finalized for Implementation  
+**Implementation:** 5 Stages  
+**Cost:** $0 (uses existing RDS infrastructure)
+
+### What We're Implementing
+
+PostgreSQL native Full-Text Search combined with the pg_trgm extension to provide:
+
+- **Keyword Search:** Find help requests, users, and volunteers by exact terms
+- **Fuzzy Matching:** Handle typos and partial matches automatically
+- **Ranked Results:** Return most relevant results first
+- **Multi-language Support:** Search in English, Hindi, Spanish, and more
+- **Autocomplete:** Provide typeahead suggestions as users type
+- **Real-time Indexing:** Updates automatically with data changes
+
+### Why This Approach
+
+- **Zero Infrastructure Cost:** Runs inside existing RDS instance
+- **No Data Sync Issues:** Search data is always consistent with database
+- **ACID Compliance:** Maintains transactional integrity
+- **Battle-Tested:** PostgreSQL FTS has 15+ years in production use
+- **Scalable:** Handles 1M-10M records efficiently
+- **Easy Maintenance:** One-time setup, auto-updating via triggers
+
+---
+
+## Phase 1: Implementation Checklist
+
+### Stage 1: Setup & Foundation
+
+**Objective:** Enable extensions and prepare infrastructure
+
+- [ ] **Enable pg_trgm extension** on RDS PostgreSQL
+  - Connect to QA database
+  - Run: `CREATE EXTENSION IF NOT EXISTS pg_trgm;`
+  - Verify installation
+  - Test on QA environment
+- [ ] **Backup production database** before changes
+- [ ] **Document rollback procedure**
+- [ ] **Create migration scripts directory** (`database/ddl/Search/`)
+
+**Deliverables:**
+
+- `01_enable_extensions.sql` - Extension setup script
+- Rollback documentation
+- QA environment tested and verified
+
+---
+
+### Stage 2: Request Search Implementation
+
+**Objective:** Enable search on help requests (highest priority)
+
+**Target Table:** `request`  
+**Searchable Fields:** `req_subj`, `req_desc`, `req_loc`
+
+**Tasks:**
+
+- [ ] **Add search_vector column** to request table
+
+  ```sql
+  ALTER TABLE request ADD COLUMN search_vector tsvector
+    GENERATED ALWAYS AS (
+      to_tsvector('english',
+        coalesce(req_subj, '') || ' ' ||
+        coalesce(req_desc, '') || ' ' ||
+        coalesce(req_loc, '')
+      )
+    ) STORED;
+  ```
+
+- [ ] **Create GIN indexes** for fast searching
+
+  ```sql
+  -- Full-text search index
+  CREATE INDEX idx_request_search_vector
+    ON request USING GIN(search_vector);
+
+  -- Fuzzy/typo tolerance indexes
+  CREATE INDEX idx_request_subj_trgm
+    ON request USING GIN(req_subj gin_trgm_ops);
+
+  CREATE INDEX idx_request_desc_trgm
+    ON request USING GIN(req_desc gin_trgm_ops);
+  ```
+
+- [ ] **Create search function**
+
+  ```sql
+  CREATE FUNCTION search_requests(
+    query_text TEXT,
+    limit_results INT DEFAULT 20
+  ) RETURNS TABLE (...) AS $$ ... $$;
+  ```
+
+- [ ] **Test queries**
+  - Keyword search: "emergency medical help"
+  - Fuzzy search: "emergancy" → finds "emergency"
+  - Location search: "San Jose"
+  - Phrase search: "urgent medical assistance"
+
+**Deliverables:**
+
+- `02_request_search.sql` - Complete implementation
+- Search function for API integration
+- Test query results documented
+
+**PRD Alignment:**
+
+- ✓ Users can search help requests by keywords
+- ✓ Search handles typos automatically
+- ✓ Results ranked by relevance
+- ✓ Search performance <100ms
+
+---
+
+### Stage 3: User & Volunteer Search
+
+**Objective:** Enable searching for users and volunteers
+
+**Target Tables:** `users`, `volunteer_details`  
+**Searchable Fields:**
+
+- Users: `full_name`, `first_name`, `last_name`, `primary_email_address`
+- Volunteers: `skills` (JSONB), location, availability
+
+**Tasks:**
+
+- [ ] **Add search columns to users table**
+
+  ```sql
+  ALTER TABLE users ADD COLUMN search_vector tsvector
+    GENERATED ALWAYS AS (
+      to_tsvector('english',
+        coalesce(full_name, '') || ' ' ||
+        coalesce(primary_email_address, '') || ' ' ||
+        coalesce(city_name, '')
+      )
+    ) STORED;
+  ```
+
+- [ ] **Create indexes**
+
+  ```sql
+  CREATE INDEX idx_users_search_vector
+    ON users USING GIN(search_vector);
+
+  CREATE INDEX idx_users_name_trgm
+    ON users USING GIN(full_name gin_trgm_ops);
+  ```
+
+- [ ] **Handle JSONB skill search** in volunteer_details
+
+  ```sql
+  CREATE INDEX idx_volunteer_skills_gin
+    ON volunteer_details USING GIN(skills jsonb_path_ops);
+  ```
+
+- [ ] **Create volunteer search view**
+  - Combine user info + volunteer details + skills
+  - Include availability and location
+
+- [ ] **Create search functions**
+  - `search_users(query_text)` - Find users by name/email
+  - `search_volunteers(query_text, skills)` - Find volunteers by skills
+
+**Deliverables:**
+
+- `03_user_volunteer_search.sql` - Implementation
+- Volunteer matching function
+- Admin search API queries
+
+**PRD Alignment:**
+
+- ✓ Admin can search users by name/email
+- ✓ System can match volunteers by skills
+- ✓ Search handles name variations (Jon → John)
+- ✓ Volunteer discovery by location and skills
+
+---
+
+### Stage 4: Categories & Advanced Features
+
+**Objective:** Complete search implementation with categories and enhancements
+
+**Target Tables:** `help_categories`, `organizations`
+
+**Tasks:**
+
+- [ ] **Add FTS to help_categories**
+
+  ```sql
+  ALTER TABLE help_categories ADD COLUMN search_vector tsvector
+    GENERATED ALWAYS AS (
+      to_tsvector('english',
+        coalesce(cat_name, '') || ' ' ||
+        coalesce(cat_desc, '')
+      )
+    ) STORED;
+  ```
+
+- [ ] **Implement category autocomplete**
+  - Typeahead suggestions as users type
+  - Use pg_trgm for partial matching
+
+- [ ] **Add multi-language support**
+  - Configure text search for Hindi, Spanish
+  - Create language-specific dictionaries
+
+  ```sql
+  CREATE TEXT SEARCH CONFIGURATION hindi (COPY = simple);
+  CREATE TEXT SEARCH CONFIGURATION spanish (COPY = spanish);
+  ```
+
+- [ ] **Implement search filters**
+  - Date range (submission_date, serviced_date)
+  - Location (city, state)
+  - Status (req_status_id)
+  - Priority (req_priority_id)
+  - Category (req_cat_id)
+
+- [ ] **Add search highlighting**
+  - Show matched terms in results
+  - Use `ts_headline` function
+
+- [ ] **Create search analytics table**
+
+  ```sql
+  CREATE TABLE search_logs (
+    log_id SERIAL PRIMARY KEY,
+    query_text TEXT,
+    user_id VARCHAR(255),
+    results_count INT,
+    execution_time_ms INT,
+    searched_at TIMESTAMP DEFAULT NOW()
+  );
+  ```
+
+**Deliverables:**
+
+- `04_categories_advanced_search.sql` - Implementation
+- Autocomplete API endpoint
+- Multi-language search configuration
+- Search analytics dashboard queries
+
+**PRD Alignment:**
+
+- ✓ Users can browse/search help categories
+- ✓ Autocomplete suggests relevant categories
+- ✓ Multi-language search support
+- ✓ Search analytics for improving UX
+- ✓ Filter results by multiple criteria
+
+---
+
+### Stage 5: Testing & Optimization
+
+**Objective:** Ensure production readiness and optimal performance
+
+**Tasks:**
+
+- [ ] **Performance testing**
+  - Test with 10K, 100K, 1M records
+  - Measure query latency (target: <100ms p95)
+  - Test concurrent searches (target: 100+ simultaneous)
+
+- [ ] **Optimize indexes**
+  - Analyze index usage: `pg_stat_user_indexes`
+  - Remove unused indexes
+  - Adjust GIN index parameters if needed
+
+- [ ] **Add query result caching**
+  - Cache frequent searches (Redis or pg_prewarm)
+  - Set appropriate TTL (5-15 minutes)
+
+- [ ] **Setup monitoring**
+  - CloudWatch metrics for query performance
+  - Alerts for slow queries (>500ms)
+  - Track search usage patterns
+
+- [ ] **Load testing**
+  - Simulate 1000 concurrent searches
+  - Test under peak load conditions
+  - Verify no performance degradation
+
+- [ ] **Documentation**
+  - API documentation for search endpoints
+  - Query examples and best practices
+  - Troubleshooting guide
+
+**Deliverables:**
+
+- Performance benchmark report
+- CloudWatch dashboard
+- Load testing results
+- Complete search API documentation
+
+**PRD Alignment:**
+
+- ✓ Search performs under load (<100ms)
+- ✓ System monitoring in place
+- ✓ Production-ready implementation
+- ✓ Documentation for developers
+
+---
+
+## Phase 1: Expected Outcomes
+
+### Performance Metrics
+
+| Metric                | Target | How We Measure              |
+| --------------------- | ------ | --------------------------- |
+| Query Latency (p95)   | <100ms | CloudWatch metrics          |
+| Index Update Time     | <10ms  | PostgreSQL logs             |
+| Autocomplete Response | <50ms  | API monitoring              |
+| Concurrent Users      | 100+   | Load testing                |
+| Search Relevance      | >95%   | User feedback / A/B testing |
+
+### PRD Requirements Met
+
+**Search Functionality:**
+
+- ✓ Full-text keyword search across requests
+- ✓ Fuzzy matching for typos (1-2 character errors)
+- ✓ Ranked results by relevance
+- ✓ Multi-field search (title, description, location)
+- ✓ Autocomplete/typeahead suggestions
+- ✓ Filter by date, status, priority, category, location
+
+**User Experience:**
+
+- ✓ Fast response times (<100ms)
+- ✓ Handles misspellings gracefully
+- ✓ Shows relevant results first
+- ✓ Multi-language support (English, Hindi, Spanish)
+
+**Admin Features:**
+
+- ✓ Search users by name/email
+- ✓ Find volunteers by skills/location
+- ✓ Search analytics dashboard
+- ✓ Filter and export search results
+
+**Technical Requirements:**
+
+- ✓ Zero additional infrastructure cost
+- ✓ ACID compliant (consistent results)
+- ✓ Auto-updating indexes
+- ✓ Scalable to 1M+ records
+
+---
+
+## Phase 2: Semantic Search with pgvector
+
+**Status:** Future Enhancement (6-12 months)  
+**Implementation:** 3 Stages  
+**Cost:** $20-50/month (OpenAI embeddings)
+
+### What Is Semantic Search?
+
+Semantic search understands the **meaning** of queries, not just exact keywords:
+
+- **Example 1:** Search "heart attack" → finds "cardiac arrest", "chest pain", "myocardial infarction"
+- **Example 2:** Search "feeling alone" → finds "depression", "isolation", "loneliness"
+- **Example 3:** Search "need doctor" → finds "medical help", "physician", "healthcare"
+
+### Why Add pgvector?
+
+**Advantages Over FTS + pg_trgm:**
+
+1. **Conceptual Understanding**
+   - FTS: Matches words literally
+   - pgvector: Understands synonyms and related concepts
+
+2. **Cross-Language Search**
+   - Search in English → find Hindi/Spanish results
+   - Unified search across languages
+
+3. **Duplicate Detection**
+   - Find similar requests automatically
+   - Prevent duplicate help requests
+
+4. **Smarter Volunteer Matching**
+   - Match volunteers based on skill semantics
+   - "Python developer" matches "software engineer", "programmer"
+
+5. **Better User Experience**
+   - Users don't need exact keywords
+   - More forgiving search
+   - Higher result relevance
+
+### How pgvector Works
+
+```
+1. User searches: "need help with groceries"
+   ↓
+2. Convert query to embedding (vector): [0.23, -0.45, 0.67, ...]
+   ↓
+3. Find requests with similar embeddings (cosine similarity)
+   ↓
+4. Return: "food assistance", "meal delivery", "grocery shopping help"
+```
+
+**Embeddings** = Numeric representations of text meaning (1536 dimensions)
+
+---
+
+## Phase 2: Implementation Checklist
+
+### Stage 1: pgvector Setup
+
+**Objective:** Enable pgvector and generate embeddings
+
+**Tasks:**
+
+- [ ] **Enable pgvector extension**
+
+  ```sql
+  CREATE EXTENSION IF NOT EXISTS vector;
+  ```
+
+- [ ] **Add embedding columns**
+
+  ```sql
+  ALTER TABLE request
+    ADD COLUMN search_embedding vector(1536);
+
+  ALTER TABLE users
+    ADD COLUMN profile_embedding vector(1536);
+
+  ALTER TABLE volunteer_details
+    ADD COLUMN skills_embedding vector(1536);
+  ```
+
+- [ ] **Create vector indexes**
+
+  ```sql
+  CREATE INDEX idx_request_embedding
+    ON request USING ivfflat(search_embedding vector_cosine_ops)
+    WITH (lists = 100);
+  ```
+
+- [ ] **Setup embedding generation**
+  - Option A: OpenAI API integration
+  - Option B: Self-hosted model (sentence-transformers)
+  - Create Lambda/script for batch generation
+
+- [ ] **Generate embeddings for existing data**
+  - Batch process: 1000 records at a time
+  - Estimate: ~10K requests × $0.0001 = $1 one-time
+
+**Deliverables:**
+
+- `05_pgvector_setup.sql` - Schema changes
+- Embedding generation script
+- Cost analysis and monitoring
+
+---
+
+### Stage 2: Hybrid Search Implementation
+
+**Objective:** Combine FTS + pg_trgm + pgvector for best results
+
+**Tasks:**
+
+- [ ] **Create hybrid search function**
+
+  ```sql
+  CREATE FUNCTION search_requests_hybrid(
+    query_text TEXT,
+    query_embedding vector(1536),
+    keyword_weight FLOAT DEFAULT 0.4,
+    fuzzy_weight FLOAT DEFAULT 0.2,
+    semantic_weight FLOAT DEFAULT 0.4
+  ) RETURNS TABLE (...) AS $$
+    -- Combine all three search methods
+    -- Weight and rank results
+  $$ LANGUAGE plpgsql;
+  ```
+
+- [ ] **Implement semantic duplicate detection**
+  - Find similar requests automatically
+  - Alert users about existing requests
+  - Reduce duplicate help requests
+
+- [ ] **Enhanced volunteer matching**
+  - Match by skill embeddings
+  - Consider semantic similarity
+  - Rank volunteers by relevance
+
+- [ ] **Cross-language search**
+  - Generate embeddings in multiple languages
+  - Unified search experience
+
+**Deliverables:**
+
+- `06_hybrid_search.sql` - Complete implementation
+- Duplicate detection service
+- Enhanced volunteer matching algorithm
+
+---
+
+### Stage 3: Testing & Integration
+
+**Objective:** Validate semantic search quality and integrate with API
+
+**Tasks:**
+
+- [ ] **Quality testing**
+  - Test semantic search accuracy
+  - Compare with FTS-only results
+  - A/B test with real users
+
+- [ ] **Performance tuning**
+  - Optimize vector index parameters
+  - Test query latency (target: <150ms)
+  - Cache embeddings for frequent queries
+
+- [ ] **API integration**
+  - Update search endpoints
+  - Add hybrid search option
+  - Backward compatible with Phase 1
+
+- [ ] **Cost monitoring**
+  - Track embedding API usage
+  - Optimize batch generation
+  - Set budget alerts
+
+**Deliverables:**
+
+- Quality comparison report
+- Updated API documentation
+- Cost monitoring dashboard
+
+---
+
+## Phase 2: Expected Outcomes
+
+### Enhanced Capabilities
+
+| Feature             | Phase 1 (FTS + pg_trgm) | Phase 2 (+ pgvector) | Improvement |
+| ------------------- | ----------------------- | -------------------- | ----------- |
+| Keyword match       | Excellent               | Excellent            | Same        |
+| Typo tolerance      | Excellent               | Excellent            | Same        |
+| Synonym matching    | None                    | Excellent            | ✓ New       |
+| Conceptual search   | None                    | Excellent            | ✓ New       |
+| Cross-language      | Limited                 | Excellent            | ✓ Major     |
+| Duplicate detection | Manual                  | Automatic            | ✓ New       |
+| Relevance score     | Good (85%)              | Excellent (95%+)     | ✓ +10%      |
+
+### PRD Requirements Met (Additional)
+
+**Enhanced Search:**
+
+- ✓ Understands synonyms and related concepts
+- ✓ Cross-language search capability
+- ✓ Finds conceptually similar requests
+- ✓ Automatic duplicate detection
+
+**Smarter Matching:**
+
+- ✓ Semantic volunteer-to-request matching
+- ✓ Skill-based recommendations
+- ✓ Context-aware search results
+
+**User Experience:**
+
+- ✓ More forgiving search (no exact keywords needed)
+- ✓ Higher relevance scores
+- ✓ Reduced duplicate requests
+
+### Cost Analysis
+
+**Monthly Operational Cost:**
+
+| Component                           | Cost       | Notes                            |
+| ----------------------------------- | ---------- | -------------------------------- |
+| Infrastructure                      | $0         | Uses existing RDS                |
+| Embedding generation (new requests) | $5-10      | ~50-100 requests/day             |
+| Embedding generation (users)        | $1-2       | ~10-20 new users/day             |
+| API calls (search)                  | $10-20     | Cached embeddings, minimal calls |
+| **Total Monthly**                   | **$20-50** | Scales with usage                |
+
+**One-time Setup Cost:**
+
+- Existing data embeddings: ~$1-5 (10K-50K records)
+
+---
+
+## Success Metrics & Monitoring
+
+### Phase 1 Metrics
+
+```sql
+-- Query performance
+SELECT
+  AVG(execution_time_ms) as avg_latency,
+  PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY execution_time_ms) as p95_latency,
+  COUNT(*) as total_searches
+FROM search_logs
+WHERE searched_at > NOW() - INTERVAL '24 hours';
+
+-- Search volume
+SELECT
+  DATE(searched_at) as date,
+  COUNT(*) as searches,
+  COUNT(DISTINCT user_id) as unique_users
+FROM search_logs
+GROUP BY DATE(searched_at)
+ORDER BY date DESC;
+
+-- Popular queries
+SELECT
+  query_text,
+  COUNT(*) as frequency,
+  AVG(results_count) as avg_results
+FROM search_logs
+GROUP BY query_text
+ORDER BY frequency DESC
+LIMIT 20;
+```
+
+### Phase 2 Metrics
+
+```sql
+-- Semantic search quality
+SELECT
+  query_text,
+  search_type, -- 'keyword' vs 'semantic'
+  AVG(click_through_rate) as ctr,
+  AVG(time_to_first_click) as engagement
+FROM search_analytics
+GROUP BY query_text, search_type;
+
+-- Duplicate detection effectiveness
+SELECT
+  COUNT(*) as duplicates_prevented,
+  SUM(estimated_time_saved_hours) as hours_saved
+FROM duplicate_detections
+WHERE detected_at > NOW() - INTERVAL '30 days';
+```
+
+---
+
+## Quick Start Guide
+
+### Running Phase 1 Implementation
+
+```bash
+# 1. Connect to your database
+psql -h your-rds-endpoint.rds.amazonaws.com \
+     -U postgres \
+     -d virginia_dev_saayam_rdbms
+
+# 2. Run migration scripts in order
+\i database/ddl/Search/codes/01_enable_fuzzy_search.sql
+\i database/ddl/Search/codes/02_add_request_search.sql
+\i database/ddl/Search/codes/03_add_user_and_volunteer_search.sql
+\i database/ddl/Search/codes/04_add_category_and_advanced_search.sql
+
+# 3. Test search functionality
+SELECT * FROM search_requests('emergency medical');
+SELECT * FROM search_users('john');
+SELECT * FROM search_volunteers('python programming');
+
+# 4. Verify indexes
+SELECT schemaname, tablename, indexname, idx_scan
+FROM pg_stat_user_indexes
+WHERE tablename IN ('request', 'users', 'volunteer_details');
+```
+
+### Running Phase 2 Implementation
+
+```bash
+# 1. Enable pgvector
+\i database/ddl/Search/codes/05_enable_semantic_search_pgvector.sql
+
+# 2. Generate embeddings (Python script)
+python scripts/generate_embeddings.py --batch-size 1000
+
+# 3. Implement hybrid search
+\i database/ddl/Search/codes/06_add_hybrid_search.sql
+
+# 4. Test semantic search
+SELECT * FROM search_requests_hybrid(
+  'need help with groceries',
+  get_embedding('need help with groceries')
+);
+```
+
+---
+
+## Resources & Documentation
+
+### PostgreSQL Documentation
+
+- [Full-Text Search](https://www.postgresql.org/docs/current/textsearch.html)
+- [pg_trgm Extension](https://www.postgresql.org/docs/current/pgtrgm.html)
+- [pgvector Extension](https://github.com/pgvector/pgvector)
+
+### Implementation Guides
+
+- `database/ddl/Search/00_pgvector_integration_guide.md` - Detailed pgvector integration
+- API documentation (to be created in Phase 1, Stage 5)
+
+### Support
+
+- PostgreSQL community forums
+- pgvector GitHub issues
+- OpenAI API documentation (for embeddings)
+
+---
+
+## Implementation Summary
+
+**Phase 1 (FTS + pg_trgm):**
+
+- Stage 1: Setup & Foundation
+- Stage 2: Request Search
+- Stage 3: User & Volunteer Search
+- Stage 4: Categories & Advanced Features
+- Stage 5: Testing & Optimization
+- **Total: 5 Stages, Production-ready**
+
+**Phase 2 (+ pgvector):**
+
+- Stage 1: pgvector Setup
+- Stage 2: Hybrid Search Implementation
+- Stage 3: Testing & Integration
+- **Total: 3 Stages, Enhanced capabilities**
+
+**Recommended Start for Phase 2:** 6-12 months after Phase 1 deployment, based on user feedback and search analytics.

--- a/rds-terraform/main.tf
+++ b/rds-terraform/main.tf
@@ -1,0 +1,80 @@
+==========================================================================
+# Main Terraform Script to create the RDS instance based on passed values#
+==========================================================================
+
+terraform {
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"    # Official AWS provider from HashiCorp
+      version = "~> 5.0"           
+    }
+  }
+  required_version = ">= 1.0"      
+}
+
+# =============================================================================
+# AWS PROVIDER CONFIGURATION
+# =============================================================================
+provider "aws" {
+  region = var.aws_region          # region we specify in variables
+}
+
+
+# =============================================================================
+# RDS POSTGRESQL DATABASE INSTANCE
+# =============================================================================
+
+resource "aws_db_instance" "postgres_db" {
+  
+  # -------------------------------------------------------------------------
+  # BASIC DATABASE CONFIGURATION
+  # -------------------------------------------------------------------------
+  identifier     = "${var.environment}-postgres-db"  
+  engine         = "postgres"                         
+  instance_class = var.db_instance_class             
+
+  # -------------------------------------------------------------------------
+  # STORAGE CONFIGURATION 
+  # -------------------------------------------------------------------------
+  allocated_storage = var.allocated_storage          
+  storage_type      = "gp2"                         # General Purpose SSD (cheapest option)
+  storage_encrypted = true                          # Encrypt data at rest (FREE security feature)
+
+  # -------------------------------------------------------------------------
+  # DATABASE ACCESS CREDENTIALS
+  # -------------------------------------------------------------------------
+  db_name  = var.database_name                      # Name of the database inside PostgreSQL
+  username = var.db_username                        # Admin username for database
+  
+  password = var.db_password
+
+  # -------------------------------------------------------------------------
+  # NETWORK SECURITY CONFIGURATION
+  # -------------------------------------------------------------------------
+  vpc_security_group_ids = [var.vpc_security_group_id]  
+  publicly_accessible    = false                        # NO public internet access
+  
+
+  # -------------------------------------------------------------------------
+  # BACKUP CONFIGURATION 
+  # -------------------------------------------------------------------------
+  backup_retention_period = var.backup_retention_period  # How many days to keep backups
+
+  # -------------------------------------------------------------------------
+  # CLEANUP CONFIGURATION
+  # -------------------------------------------------------------------------
+  skip_final_snapshot = var.skip_final_snapshot      # When deleting DB:
+  # true = Delete immediately 
+  # false = Take final backup before deleting (costs extra)
+
+  # -------------------------------------------------------------------------
+  # OPTIONAL: RESOURCE TAGS FOR ORGANIZATION
+  # -------------------------------------------------------------------------
+  # These are just labels - they don't cost anything but help organize resources
+  tags = {
+    Name        = "${var.environment}-postgres-db"   
+    Environment = var.environment                     
+  }
+}
+

--- a/rds-terraform/outputs.tf
+++ b/rds-terraform/outputs.tf
@@ -1,0 +1,46 @@
+
+
+# =============================================================================
+# DATABASE CONNECTION INFORMATION
+# =============================================================================
+
+output "db_endpoint" {
+  description = "Database server address/hostname for connections"
+  value       = aws_db_instance.postgres_db.endpoint
+  
+}
+
+output "db_port" {
+  description = "Database port number"
+  value       = aws_db_instance.postgres_db.port
+  
+}
+
+output "db_name" {
+  description = "Database name to connect to"
+  value       = aws_db_instance.postgres_db.db_name
+}
+
+output "db_username" {
+  description = "Database admin username"
+  value       = aws_db_instance.postgres_db.username
+  sensitive   = true 
+}
+
+
+# =============================================================================
+# AWS RESOURCE INFORMATION
+# =============================================================================
+
+output "db_instance_id" {
+  description = "AWS RDS instance identifier"
+  value       = aws_db_instance.postgres_db.id
+ 
+}
+
+output "db_security_group_id" {
+  description = "Security group ID attached to the database"
+  value       = var.vpc_security_group_id
+  
+}
+

--- a/rds-terraform/pulumi/Pulumi.dev.yaml
+++ b/rds-terraform/pulumi/Pulumi.dev.yaml
@@ -1,0 +1,12 @@
+config:
+  # Required Configuration
+  rds-deployment:aws_region: "eu-west-1"
+  rds-deployment:environment: "dev"
+  rds-deployment:db_instance_class: "db.t3.micro"
+  rds-deployment:vpc_security_group_id: ""  # Replace with your SG ID
+  
+  # Provide Database Credentials
+  rds-deployment:database_name: ""
+  rds-deployment:db_username: ""
+  rds-deployment:db_password:
+    secure: "" 

--- a/rds-terraform/pulumi/Pulumi.yaml
+++ b/rds-terraform/pulumi/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: rds-qa-infra
+runtime: python
+description: Pulumi project for deploying the QA PostgreSQL RDS instance in eu-west-1

--- a/rds-terraform/pulumi/Pulumi_Test_Validation.md
+++ b/rds-terraform/pulumi/Pulumi_Test_Validation.md
@@ -1,0 +1,154 @@
+# Pulumi RDS QA – Errors, Causes, and Resolution
+
+---
+
+## 1. Missing Pulumi Project File
+
+### Error
+
+error: could not detect current project: no Pulumi.yaml project file found
+
+### Cause
+
+Pulumi requires a `Pulumi.yaml` file to identify a project.
+Without it, no stack or preview can be executed.
+
+### Resolution
+
+Ensure `Pulumi.yaml` exists at the project root and defines:
+
+- Project name
+- Runtime (python)
+
+Status: **Resolved**
+
+---
+
+## 2. Missing Python Pulumi SDK
+
+### Error
+
+ModuleNotFoundError: No module named ‘pulumi’
+
+### Cause
+
+The Pulumi Python SDK was not installed in the active environment.
+
+### Resolution
+
+Activate the virtual environment and install dependencies:
+
+pip install pulumi pulumi-aws
+
+Status: **Resolved**
+
+---
+
+## 3. Missing Required Configuration Keys
+
+### Error
+
+Missing required configuration variable ‘rds-deployment:aws_region’
+
+(similar errors for `environment`, `db_instance_class`,
+`vpc_security_group_id`, `db_password`)
+
+### Cause
+
+The Pulumi program enforces required configuration keys at runtime.
+If any are missing, execution fails fast.
+
+### Resolution
+
+Set required configuration values using:
+
+pulumi config set  
+pulumi config set –secret
+
+Status: **Resolved (validated behavior)**
+
+---
+
+## 4. Secret Handling Validation
+
+### Error
+
+Triggered when attempting to store sensitive values without `--secret`.
+
+### Cause
+
+Pulumi enforces encrypted storage for secrets.
+Unmarked secrets are rejected by design.
+
+### Resolution
+
+Always store sensitive values using:
+
+pulumi config set rds-deployment:db_password –secret
+
+Status: **Resolved (validated behavior)**
+
+---
+
+## 5. Missing AWS Credentials
+
+### Error
+
+No valid credential sources found.
+
+### Cause
+
+Pulumi requires programmatic AWS credentials.
+Console-only AWS access is insufficient.
+
+### Resolution
+
+One of the following is required:
+
+- AWS SSO CLI authentication
+- Assume-role access
+- QA-scoped access keys provided by DevSecOps
+
+Status: **Blocked (external dependency)**
+
+---
+
+## 6. IAM Permission Errors
+
+### Error
+
+AccessDenied: iam:ListUsers
+
+### Cause
+
+The current AWS identity does not have IAM permissions.
+This is expected for restricted QA users.
+
+### Resolution
+
+IAM permissions are managed externally by DevSecOps.
+No changes are required in the Pulumi code.
+
+Status: **Blocked (external dependency)**
+
+---
+
+## Summary
+
+### Validated
+
+- Pulumi project structure
+- Configuration enforcement
+- Secret handling
+- Failure behavior without AWS access
+- Provider authentication error clarity
+
+### Blocked
+
+- End-to-end RDS provisioning
+- AWS-side resource validation
+- Cleanup and destroy validation
+
+All blocked items require **QA programmatic AWS access** and explicit approval.
+
+No AWS resources have been created or modified.

--- a/rds-terraform/pulumi/README.md
+++ b/rds-terraform/pulumi/README.md
@@ -1,0 +1,28 @@
+# RDS PostgreSQL Deployment - DEV Environment
+
+Deploy AWS RDS PostgreSQL database for development using Pulumi.
+
+## Quick Start
+
+### 1. Install Requirements
+```bash
+pip install pulumi pulumi-aws
+```
+### 2. Edit Configuration
+
+Open `Pulumi.dev.yaml` and replace:
+- `` with your actual AWS Security Group ID
+
+### 3. Deploy
+```bash
+# Preview what will be created
+pulumi preview
+
+# Create the database
+pulumi up
+```
+
+## 4. Delete Everything
+```bash
+pulumi destroy
+```

--- a/rds-terraform/pulumi/main.py
+++ b/rds-terraform/pulumi/main.py
@@ -1,0 +1,44 @@
+"""
+Pulumi script to deploy RDS PostgreSQL instance
+"""
+
+import pulumi
+import pulumi_aws as aws
+
+# Read configuration values
+config = pulumi.Config()
+aws_region = config.require("aws_region")
+environment = config.require("environment")
+db_instance_class = config.require("db_instance_class")
+vpc_security_group_id = config.require("vpc_security_group_id")
+
+# Optional configs
+database_name = config.get("database_name") 
+db_username = config.get("db_username")
+db_password = config.require("db_password")  # Must provide password for now
+
+# Create RDS instance
+rds_instance = aws.rds.Instance(
+    "postgres-db",
+    identifier=f"{environment}-postgres-db",
+    engine="postgres",
+    instance_class=db_instance_class,
+    allocated_storage=20,
+    storage_type="",
+    storage_encrypted=True,
+    db_name=database_name,
+    username=db_username,
+    password=db_password,
+    vpc_security_group_ids=[vpc_security_group_id],
+    publicly_accessible=False,
+    skip_final_snapshot=True,
+    backup_retention_period=0,
+    tags={
+        "Name": f"{environment}-postgres-db",
+        "Environment": environment,
+    }
+)
+
+# Export basic outputs
+pulumi.export("db_endpoint", rds_instance.endpoint)
+pulumi.export("db_name", rds_instance.db_name)

--- a/rds-terraform/qa.tfvars
+++ b/rds-terraform/qa.tfvars
@@ -1,0 +1,19 @@
+# =============================================================================
+# tfvars to pass parameterized inputs tot he terraform script
+# =============================================================================
+# 1. We can create similar tfvars for different instances, this way the main terraform deployment script stays untouched and we can deploy the instance across different regions with custom parameters
+===============================================================================
+
+aws_region              = "eu-west-1"           # Placeholder for EU region, will update accordingly
+environment             = "qa"                  #  environment
+db_instance_class       = "db.t3.micro"         
+vpc_security_group_id   = "" # saayam vpc group id
+
+# Optional customizations 
+database_name           = "saayam_qa_db"        # Placeholder Database name will update accordingly
+db_username             = "qa_admin"             # Username
+db_password             = "" # need to discuss on appropriate password passing approach
+allocated_storage       = 20                    
+backup_retention_period = 0                    
+skip_final_snapshot     = true                  
+

--- a/rds-terraform/variables.tf
+++ b/rds-terraform/variables.tf
@@ -1,0 +1,82 @@
+# =============================================================================
+# TERRAFORM VARIABLES DEFINITION FILE
+# =============================================================================
+# This file defines all the parameters you can customize when deploying
+# the database.
+
+# =============================================================================
+# REQUIRED VARIABLES
+# =============================================================================
+
+variable "aws_region" {
+  description = "AWS region where the database will be created (e.g., eu-west-1 for Ireland)"
+  type        = string
+  # Example values:
+  # - "eu-west-1"     = Ireland
+  # - "eu-central-1"  = Frankfurt 
+  # - "eu-west-2"     = London
+  # - "us-east-1"     = N. Virginia
+}
+
+variable "environment" {
+  description = "Environment name - used in naming and tagging resources"
+  type        = string
+  # Example values: "qa", "staging", "prod", "dev"
+  
+}
+
+variable "db_instance_class" {
+  description = "The size/type of the database server"
+  type        = string
+}
+
+variable "vpc_security_group_id" {
+  description = "ID of your existing VPC security group"
+  type        = string
+}
+
+# =============================================================================
+# OPTIONAL VARIABLES (Have defaults but can be customized)
+# =============================================================================
+
+variable "database_name" {
+  description = "Name of the database that will be created inside PostgreSQL"
+  type        = string
+  default     = "saayam_db"
+  
+}
+
+variable "db_username" {
+  description = "Admin username for the database"
+  type        = string
+  default     = "saayam_admin"
+}
+
+variable "db_password" {
+  description = "Password for the database admin user"
+  type        = string
+  default     = ""           
+  sensitive   = true         # Terraform won't display this in logs
+  
+}
+
+variable "allocated_storage" {
+  description = "Initial database storage size in GB"
+  type        = number
+  default     = 20
+  
+}
+
+variable "backup_retention_period" {
+  description = "How many days to keep automatic database backups (0 = no backups)"
+  type        = number
+  default     = 0            # No backups by default ()
+  
+}
+
+variable "skip_final_snapshot" {
+  description = "Skip taking a final backup when deleting the database"
+  type        = bool
+  default     = true         # Skip by default (faster deletion, no extra cost)
+  
+}


### PR DESCRIPTION

  ### Description

  This PR sets up the search migration foundation and implements Phase 1 request search.

  ### What changed

  - Reorganized search artifacts under:
      - ddl/Search/docs/
      - ddl/Search/codes/
  - Implemented `ddl/Search/codes/01_enable_fuzzy_search.sql`
      - enables `pg_trgm`
  - Implemented `ddl/Search/codes/02_add_request_search.sql`
      - adds generated search_vector on virginia_dev_saayam_rdbms.request
      - adds GIN/trigram indexes
      - adds virginia_dev_saayam_rdbms.search_requests(query_text, limit_results) with combined FTS + fuzzy ranking
  - Updated search plan doc paths/names to match new structure.

  ### Local testing

  Executed locally on disposable DB saayam_search_local_test:

  - applied 01_enable_fuzzy_search.sql
  - applied 02_add_request_search.sql
  - smoke queries passed:
      - keyword: emergency medical
      - typo: emergancy
      - location: San Jose

 

  ### Future plan

  - `03_add_user_and_volunteer_search.sql`: users + volunteer search vectors/indexes/functions
  - `04_add_category_and_advanced_search.sql`: category search, filters, highlighting, logs
  - `05_enable_semantic_search_pgvector.sql`: semantic search setup (Phase 2 foundation)