### PR TITLE
Mohith 240 sequence generators for organization tables

### DIFF
--- a/ddl/Tables/Scripts/ddl_org_seq_ireland.sql
+++ b/ddl/Tables/Scripts/ddl_org_seq_ireland.sql
@@ -1,37 +1,52 @@
--- =====================================================================
--- DDL CHANGE SCRIPT: Ireland org sequence generator
--- Idempotent migration. Differs from Virginia only in start range
--- (2 trillion) and region prefix ('002').
--- =====================================================================
+-- ============================================================================
+--  alter_org_seq_ireland.sql   (MIGRATION: old PR format -> new format)
+-- ----------------------------------------------------------------------------
+--  Moves an existing deployment from  ORG-00-001-XXX-XXX-XXX  (PR #243, Ireland = DR for Virginia)
+--  to the reviewed format             ORG-XXX-XXX-XXX-XXXX.
+--
+--  IMPORTANT — this changes BOTH the format AND the sequence range, so a plain
+--  "create if missing" cannot update the already-deployed sequence. This script
+--  therefore DROPS and RECREATES the sequence, which RESETS the counter.
+--    * SAFE  pre-launch / in dev, when NO org_id values have been issued yet.
+--    * NOT SAFE if ORG ids already exist: resetting would re-issue them, AND the
+--      already-stored old-format ids (ORG-00-001-...) would need a separate
+--      data back-fill. In that case, migrate data first, then run this.
+--
+--  Run as the OWNER of the organizations table.
+-- ============================================================================
 
-CREATE SEQUENCE IF NOT EXISTS ireland_dev_saayam_rdbms.seq_org_id
-    START WITH 2000000000000
-    INCREMENT BY 1
-    NO MAXVALUE
-    NO CYCLE;
+-- 1) Remove old objects (order: trigger -> function -> sequence) --------------
+DROP TRIGGER  IF EXISTS before_insert_organizations ON ireland_dev_saayam_rdbms.organizations;
+DROP FUNCTION IF EXISTS ireland_dev_saayam_rdbms.generate_org_id();
+DROP SEQUENCE IF EXISTS ireland_dev_saayam_rdbms.org_id_dr_seq;   -- resets counter (see note)
+
+-- 2) Recreate with the new range + format ------------------------------------
+CREATE SEQUENCE ireland_dev_saayam_rdbms.org_id_dr_seq
+    START WITH 1000000000000 INCREMENT BY 1 MINVALUE 1000000000000 MAXVALUE 1999999999999 NO CYCLE;
 
 CREATE OR REPLACE FUNCTION ireland_dev_saayam_rdbms.generate_org_id()
 RETURNS TRIGGER AS $$
 DECLARE
     seq_id BIGINT;
-    new_id TEXT;
-    region_prefix TEXT := '002';
+    padded TEXT;
 BEGIN
-    IF (NEW.org_id IS NULL) THEN
-        seq_id := nextval('ireland_dev_saayam_rdbms.seq_org_id');
-        new_id := 'ORG-00-' || region_prefix || '-' ||
-                  LPAD(FLOOR((seq_id % 1000000000) / 1000000)::TEXT, 3, '0') || '-' ||
-                  LPAD(FLOOR((seq_id % 1000000) / 1000)::TEXT, 3, '0') || '-' ||
-                  LPAD((seq_id % 1000)::TEXT, 3, '0');
-        NEW.org_id := new_id;
+    IF NEW.org_id IS NOT NULL THEN
+        RETURN NEW;
     END IF;
+    seq_id := nextval('ireland_dev_saayam_rdbms.org_id_dr_seq');
+    padded := LPAD(seq_id::TEXT, 13, '0');
+    IF length(padded) > 13 THEN
+        RAISE EXCEPTION 'org_id_dr_seq value % exceeds 13 digits; format would corrupt', seq_id;
+    END IF;
+    NEW.org_id := 'ORG-' ||
+        SUBSTRING(padded FROM 1  FOR 3) || '-' ||
+        SUBSTRING(padded FROM 4  FOR 3) || '-' ||
+        SUBSTRING(padded FROM 7  FOR 3) || '-' ||
+        SUBSTRING(padded FROM 10 FOR 4);
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 
-DROP TRIGGER IF EXISTS trg_generate_org_id
-    ON ireland_dev_saayam_rdbms.organizations;
-
-CREATE TRIGGER trg_generate_org_id
+CREATE OR REPLACE TRIGGER before_insert_organizations
     BEFORE INSERT ON ireland_dev_saayam_rdbms.organizations
     FOR EACH ROW EXECUTE FUNCTION ireland_dev_saayam_rdbms.generate_org_id();

--- a/ddl/Tables/Scripts/ddl_org_seq_ireland.sql
+++ b/ddl/Tables/Scripts/ddl_org_seq_ireland.sql
@@ -1,0 +1,37 @@
+-- =====================================================================
+-- DDL CHANGE SCRIPT: Ireland org sequence generator
+-- Idempotent migration. Differs from Virginia only in start range
+-- (2 trillion) and region prefix ('002').
+-- =====================================================================
+
+CREATE SEQUENCE IF NOT EXISTS ireland_dev_saayam_rdbms.seq_org_id
+    START WITH 2000000000000
+    INCREMENT BY 1
+    NO MAXVALUE
+    NO CYCLE;
+
+CREATE OR REPLACE FUNCTION ireland_dev_saayam_rdbms.generate_org_id()
+RETURNS TRIGGER AS $$
+DECLARE
+    seq_id BIGINT;
+    new_id TEXT;
+    region_prefix TEXT := '002';
+BEGIN
+    IF (NEW.org_id IS NULL) THEN
+        seq_id := nextval('ireland_dev_saayam_rdbms.seq_org_id');
+        new_id := 'ORG-00-' || region_prefix || '-' ||
+                  LPAD(FLOOR((seq_id % 1000000000) / 1000000)::TEXT, 3, '0') || '-' ||
+                  LPAD(FLOOR((seq_id % 1000000) / 1000)::TEXT, 3, '0') || '-' ||
+                  LPAD((seq_id % 1000)::TEXT, 3, '0');
+        NEW.org_id := new_id;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_generate_org_id
+    ON ireland_dev_saayam_rdbms.organizations;
+
+CREATE TRIGGER trg_generate_org_id
+    BEFORE INSERT ON ireland_dev_saayam_rdbms.organizations
+    FOR EACH ROW EXECUTE FUNCTION ireland_dev_saayam_rdbms.generate_org_id();

--- a/ddl/Tables/Scripts/ddl_organizations_ireland.sql
+++ b/ddl/Tables/Scripts/ddl_organizations_ireland.sql
@@ -1,61 +1,44 @@
--- =====================================================================
--- Regional Sequence Generator: ORGANIZATIONS -- IRELAND (eu-west-1)
--- EU region.
---
--- Per ADR: organizations are GLOBAL operational tables, so there is
--- NO is_eu split and NO dual generator here. Ireland differs from
--- Virginia ONLY in its sequence start range (2 trillion) and its
--- hardcoded region prefix ('002'), which together guarantee that any
--- org created in Ireland can never collide with a Virginia-native org
--- during disaster recovery / sync-back.
---
--- DECISION POINTS: identical to the Virginia file. See [D1]-[D4] there.
--- The ONLY differences from Virginia are:
---   - START WITH 2000000000000  (2 trillion)
---   - region_prefix := '002'
--- =====================================================================
+WHAT CHANGED vs PR #243:
+--    - Format: ORG-00-001-XXX-XXX-XXX  ->  ORG-XXX-XXX-XXX-XXXX (13 digits, 3-3-3-4)
+--        * dropped the constant "00" marker (differentiated nothing)
+--        * dropped the explicit "001" region sub-block (region now lives in the range)
+--    - Formatting: FLOOR/MOD math  ->  LPAD + SUBSTRING (string slicing)
+--    - Sequence range: START 2,000,000,000,000  ->  START 1,000,000,000,000, MAXVALUE 1,999,999,999,999
+--        (Ireland-DR owns the 100-band; Virginia owns the 000-band)
+--  KEPT / ADDED (not in the raw feedback snippet):
+--    - Trust-hook: a pre-supplied org_id (replication / DR copy-back) is not re-minted
+--    - Width guard: loud error if a value ever exceeds 13 digits (SUBSTRING contract)
+-- ============================================================================
 
+CREATE SEQUENCE IF NOT EXISTS ireland_dev_saayam_rdbms.org_id_dr_seq
+    START WITH 1000000000000 INCREMENT BY 1 MINVALUE 1000000000000 MAXVALUE 1999999999999 NO CYCLE;
 
--- ---------------------------------------------------------------------
--- 1. Sequence: Ireland starts at 2 trillion.
--- ---------------------------------------------------------------------
-CREATE SEQUENCE IF NOT EXISTS ireland_dev_saayam_rdbms.seq_org_id
-    START WITH 2000000000000
-    INCREMENT BY 1
-    NO MAXVALUE
-    NO CYCLE;
-
-
--- ---------------------------------------------------------------------
--- 2. Generator function (hardcoded prefix '002' for Ireland)
---    Output example: ORG-00-002-004-010-003
--- ---------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION ireland_dev_saayam_rdbms.generate_org_id()
 RETURNS TRIGGER AS $$
 DECLARE
     seq_id BIGINT;
-    new_id TEXT;
-    region_prefix TEXT := '002';   -- [D3] hardcoded: Ireland
+    padded TEXT;
 BEGIN
-    IF (NEW.org_id IS NULL) THEN
-        seq_id := nextval('ireland_dev_saayam_rdbms.seq_org_id');
-
-        new_id := 'ORG-00-' || region_prefix || '-' ||
-                  LPAD(FLOOR((seq_id % 1000000000) / 1000000)::TEXT, 3, '0') || '-' ||
-                  LPAD(FLOOR((seq_id % 1000000) / 1000)::TEXT, 3, '0') || '-' ||
-                  LPAD((seq_id % 1000)::TEXT, 3, '0');
-
-        NEW.org_id := new_id;
+    IF NEW.org_id IS NOT NULL THEN            -- replication / DR copy-back -> keep id
+        RETURN NEW;
     END IF;
 
+    seq_id := nextval('ireland_dev_saayam_rdbms.org_id_dr_seq');
+    padded := LPAD(seq_id::TEXT, 13, '0');
+
+    IF length(padded) > 13 THEN               -- SUBSTRING width contract
+        RAISE EXCEPTION 'org_id_dr_seq value % exceeds 13 digits; format would corrupt', seq_id;
+    END IF;
+
+    NEW.org_id := 'ORG-' ||
+        SUBSTRING(padded FROM 1  FOR 3) || '-' ||
+        SUBSTRING(padded FROM 4  FOR 3) || '-' ||
+        SUBSTRING(padded FROM 7  FOR 3) || '-' ||
+        SUBSTRING(padded FROM 10 FOR 4);
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 
-
--- ---------------------------------------------------------------------
--- 3. Trigger: fire before INSERT on organizations.
--- ---------------------------------------------------------------------
-CREATE TRIGGER trg_generate_org_id
+CREATE OR REPLACE TRIGGER before_insert_organizations
     BEFORE INSERT ON ireland_dev_saayam_rdbms.organizations
     FOR EACH ROW EXECUTE FUNCTION ireland_dev_saayam_rdbms.generate_org_id();

--- a/ddl/Tables/Scripts/ddl_organizations_ireland.sql
+++ b/ddl/Tables/Scripts/ddl_organizations_ireland.sql
@@ -1,0 +1,61 @@
+-- =====================================================================
+-- Regional Sequence Generator: ORGANIZATIONS -- IRELAND (eu-west-1)
+-- EU region.
+--
+-- Per ADR: organizations are GLOBAL operational tables, so there is
+-- NO is_eu split and NO dual generator here. Ireland differs from
+-- Virginia ONLY in its sequence start range (2 trillion) and its
+-- hardcoded region prefix ('002'), which together guarantee that any
+-- org created in Ireland can never collide with a Virginia-native org
+-- during disaster recovery / sync-back.
+--
+-- DECISION POINTS: identical to the Virginia file. See [D1]-[D4] there.
+-- The ONLY differences from Virginia are:
+--   - START WITH 2000000000000  (2 trillion)
+--   - region_prefix := '002'
+-- =====================================================================
+
+
+-- ---------------------------------------------------------------------
+-- 1. Sequence: Ireland starts at 2 trillion.
+-- ---------------------------------------------------------------------
+CREATE SEQUENCE IF NOT EXISTS ireland_dev_saayam_rdbms.seq_org_id
+    START WITH 2000000000000
+    INCREMENT BY 1
+    NO MAXVALUE
+    NO CYCLE;
+
+
+-- ---------------------------------------------------------------------
+-- 2. Generator function (hardcoded prefix '002' for Ireland)
+--    Output example: ORG-00-002-004-010-003
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION ireland_dev_saayam_rdbms.generate_org_id()
+RETURNS TRIGGER AS $$
+DECLARE
+    seq_id BIGINT;
+    new_id TEXT;
+    region_prefix TEXT := '002';   -- [D3] hardcoded: Ireland
+BEGIN
+    IF (NEW.org_id IS NULL) THEN
+        seq_id := nextval('ireland_dev_saayam_rdbms.seq_org_id');
+
+        new_id := 'ORG-00-' || region_prefix || '-' ||
+                  LPAD(FLOOR((seq_id % 1000000000) / 1000000)::TEXT, 3, '0') || '-' ||
+                  LPAD(FLOOR((seq_id % 1000000) / 1000)::TEXT, 3, '0') || '-' ||
+                  LPAD((seq_id % 1000)::TEXT, 3, '0');
+
+        NEW.org_id := new_id;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- ---------------------------------------------------------------------
+-- 3. Trigger: fire before INSERT on organizations.
+-- ---------------------------------------------------------------------
+CREATE TRIGGER trg_generate_org_id
+    BEFORE INSERT ON ireland_dev_saayam_rdbms.organizations
+    FOR EACH ROW EXECUTE FUNCTION ireland_dev_saayam_rdbms.generate_org_id();

--- a/ddl/Tables/ddl_org_seq_virginia.sql
+++ b/ddl/Tables/ddl_org_seq_virginia.sql
@@ -1,0 +1,35 @@
+
+-- 1. Sequence (create if missing; leave existing untouched)
+CREATE SEQUENCE IF NOT EXISTS virginia_dev_saayam_rdbms.seq_org_id
+    START WITH 1000000000000
+    INCREMENT BY 1
+    NO MAXVALUE
+    NO CYCLE;
+
+-- 2. (Re)create the generator function
+CREATE OR REPLACE FUNCTION virginia_dev_saayam_rdbms.generate_org_id()
+RETURNS TRIGGER AS $$
+DECLARE
+    seq_id BIGINT;
+    new_id TEXT;
+    region_prefix TEXT := '001';
+BEGIN
+    IF (NEW.org_id IS NULL) THEN
+        seq_id := nextval('virginia_dev_saayam_rdbms.seq_org_id');
+        new_id := 'ORG-00-' || region_prefix || '-' ||
+                  LPAD(FLOOR((seq_id % 1000000000) / 1000000)::TEXT, 3, '0') || '-' ||
+                  LPAD(FLOOR((seq_id % 1000000) / 1000)::TEXT, 3, '0') || '-' ||
+                  LPAD((seq_id % 1000)::TEXT, 3, '0');
+        NEW.org_id := new_id;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 3. Recreate the trigger (drop first so re-runs don't error)
+DROP TRIGGER IF EXISTS trg_generate_org_id
+    ON virginia_dev_saayam_rdbms.organizations;
+
+CREATE TRIGGER trg_generate_org_id
+    BEFORE INSERT ON virginia_dev_saayam_rdbms.organizations
+    FOR EACH ROW EXECUTE FUNCTION virginia_dev_saayam_rdbms.generate_org_id();

--- a/ddl/Tables/ddl_org_seq_virginia.sql
+++ b/ddl/Tables/ddl_org_seq_virginia.sql
@@ -1,35 +1,52 @@
+-- ============================================================================
+--  alter_org_seq_virginia.sql   (MIGRATION: old PR format -> new format)
+-- ----------------------------------------------------------------------------
+--  Moves an existing deployment from  ORG-00-001-XXX-XXX-XXX  (PR #243)
+--  to the reviewed format             ORG-XXX-XXX-XXX-XXXX.
+--
+--  IMPORTANT — this changes BOTH the format AND the sequence range, so a plain
+--  "create if missing" cannot update the already-deployed sequence. This script
+--  therefore DROPS and RECREATES the sequence, which RESETS the counter.
+--    * SAFE  pre-launch / in dev, when NO org_id values have been issued yet.
+--    * NOT SAFE if ORG ids already exist: resetting would re-issue them, AND the
+--      already-stored old-format ids (ORG-00-001-...) would need a separate
+--      data back-fill. In that case, migrate data first, then run this.
+--
+--  Run as the OWNER of the organizations table.
+-- ============================================================================
 
--- 1. Sequence (create if missing; leave existing untouched)
-CREATE SEQUENCE IF NOT EXISTS virginia_dev_saayam_rdbms.seq_org_id
-    START WITH 1000000000000
-    INCREMENT BY 1
-    NO MAXVALUE
-    NO CYCLE;
+-- 1) Remove old objects (order: trigger -> function -> sequence) --------------
+DROP TRIGGER  IF EXISTS before_insert_organizations ON virginia_dev_saayam_rdbms.organizations;
+DROP FUNCTION IF EXISTS virginia_dev_saayam_rdbms.generate_org_id();
+DROP SEQUENCE IF EXISTS virginia_dev_saayam_rdbms.org_id_seq;   -- resets counter (see note)
 
--- 2. (Re)create the generator function
+-- 2) Recreate with the new range + format ------------------------------------
+CREATE SEQUENCE virginia_dev_saayam_rdbms.org_id_seq
+    START WITH 1 INCREMENT BY 1 MINVALUE 1 MAXVALUE 999999999999 NO CYCLE;
+
 CREATE OR REPLACE FUNCTION virginia_dev_saayam_rdbms.generate_org_id()
 RETURNS TRIGGER AS $$
 DECLARE
     seq_id BIGINT;
-    new_id TEXT;
-    region_prefix TEXT := '001';
+    padded TEXT;
 BEGIN
-    IF (NEW.org_id IS NULL) THEN
-        seq_id := nextval('virginia_dev_saayam_rdbms.seq_org_id');
-        new_id := 'ORG-00-' || region_prefix || '-' ||
-                  LPAD(FLOOR((seq_id % 1000000000) / 1000000)::TEXT, 3, '0') || '-' ||
-                  LPAD(FLOOR((seq_id % 1000000) / 1000)::TEXT, 3, '0') || '-' ||
-                  LPAD((seq_id % 1000)::TEXT, 3, '0');
-        NEW.org_id := new_id;
+    IF NEW.org_id IS NOT NULL THEN
+        RETURN NEW;
     END IF;
+    seq_id := nextval('virginia_dev_saayam_rdbms.org_id_seq');
+    padded := LPAD(seq_id::TEXT, 13, '0');
+    IF length(padded) > 13 THEN
+        RAISE EXCEPTION 'org_id_seq value % exceeds 13 digits; format would corrupt', seq_id;
+    END IF;
+    NEW.org_id := 'ORG-' ||
+        SUBSTRING(padded FROM 1  FOR 3) || '-' ||
+        SUBSTRING(padded FROM 4  FOR 3) || '-' ||
+        SUBSTRING(padded FROM 7  FOR 3) || '-' ||
+        SUBSTRING(padded FROM 10 FOR 4);
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 
--- 3. Recreate the trigger (drop first so re-runs don't error)
-DROP TRIGGER IF EXISTS trg_generate_org_id
-    ON virginia_dev_saayam_rdbms.organizations;
-
-CREATE TRIGGER trg_generate_org_id
+CREATE OR REPLACE TRIGGER before_insert_organizations
     BEFORE INSERT ON virginia_dev_saayam_rdbms.organizations
     FOR EACH ROW EXECUTE FUNCTION virginia_dev_saayam_rdbms.generate_org_id();

--- a/ddl/ddl_changes/ddl_organizations_virginia.sql
+++ b/ddl/ddl_changes/ddl_organizations_virginia.sql
@@ -1,0 +1,59 @@
+-- =====================================================================
+-- Regional Sequence Generator: ORGANIZATIONS -- VIRGINIA (us-east-1)
+-- Primary / base region. Non-EU orgs.
+
+-- ---------------------------------------------------------------------
+-- 1. Sequence: Virginia starts at 1 trillion.
+--    NOTE ON RANGE: The ADR reserves 1-trillion..2-trillion for Virginia
+--    and 2-trillion.. for Ireland. Starting Virginia AT 1,000,000,000,000
+--    means native Virginia orgs occupy the '001' sub-block. Orgs created
+--    in Virginia's OWN region during normal operation carry prefix '001'.
+-- ---------------------------------------------------------------------
+CREATE SEQUENCE IF NOT EXISTS virginia_dev_saayam_rdbms.seq_org_id
+    START WITH 1000000000000
+    INCREMENT BY 1
+    NO MAXVALUE
+    NO CYCLE;
+
+
+-- ---------------------------------------------------------------------
+-- 2. Generator function (hardcoded prefix '001' for Virginia)
+--    Output example: ORG-00-001-004-010-003
+--    Layout: ORG-00-<region:3>-<seg1:3>-<seg2:3>-<seg3:3>
+--    Divisor math is billion-scale to support trillion ranges:
+--      seg1 = (seq % 1,000,000,000) / 1,000,000
+--      seg2 = (seq % 1,000,000)     / 1,000
+--      seg3 =  seq % 1,000
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION virginia_dev_saayam_rdbms.generate_org_id()
+RETURNS TRIGGER AS $$
+DECLARE
+    seq_id BIGINT;
+    new_id TEXT;
+    region_prefix TEXT := '001';   -- [D3] hardcoded: Virginia
+BEGIN
+    -- Only generate if caller did not supply an org_id explicitly.
+    IF (NEW.org_id IS NULL) THEN
+        seq_id := nextval('virginia_dev_saayam_rdbms.seq_org_id');
+
+        new_id := 'ORG-00-' || region_prefix || '-' ||
+                  LPAD(FLOOR((seq_id % 1000000000) / 1000000)::TEXT, 3, '0') || '-' ||
+                  LPAD(FLOOR((seq_id % 1000000) / 1000)::TEXT, 3, '0') || '-' ||
+                  LPAD((seq_id % 1000)::TEXT, 3, '0');
+
+        NEW.org_id := new_id;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- ---------------------------------------------------------------------
+-- 3. Trigger: fire before INSERT on organizations.
+--    [D1] Assumes table virginia_dev_saayam_rdbms.organizations with
+--         column org_id as PK.
+-- ---------------------------------------------------------------------
+CREATE TRIGGER trg_generate_org_id
+    BEFORE INSERT ON virginia_dev_saayam_rdbms.organizations
+    FOR EACH ROW EXECUTE FUNCTION virginia_dev_saayam_rdbms.generate_org_id();

--- a/ddl/ddl_changes/ddl_organizations_virginia.sql
+++ b/ddl/ddl_changes/ddl_organizations_virginia.sql
@@ -1,59 +1,45 @@
--- =====================================================================
--- Regional Sequence Generator: ORGANIZATIONS -- VIRGINIA (us-east-1)
--- Primary / base region. Non-EU orgs.
+-- ----------------------------------------------------------------------------
+--  WHAT CHANGED vs PR #243:
+--    - Format: ORG-00-001-XXX-XXX-XXX  ->  ORG-XXX-XXX-XXX-XXXX (13 digits, 3-3-3-4)
+--        * dropped the constant "00" marker (differentiated nothing)
+--        * dropped the explicit "001" region sub-block (region now lives in the range)
+--    - Formatting: FLOOR/MOD math  ->  LPAD + SUBSTRING (string slicing)
+--    - Sequence range: START 1,000,000,000,000  ->  START 1, MAXVALUE 999,999,999,999
+--        (Virginia now owns the 000-band; Ireland-DR owns the 100-band)
+--  KEPT / ADDED (not in the raw feedback snippet):
+--    - Trust-hook: a pre-supplied org_id (replication / DR copy-back) is not re-minted
+--    - Width guard: loud error if a value ever exceeds 13 digits (SUBSTRING contract)
+-- ============================================================================
 
--- ---------------------------------------------------------------------
--- 1. Sequence: Virginia starts at 1 trillion.
---    NOTE ON RANGE: The ADR reserves 1-trillion..2-trillion for Virginia
---    and 2-trillion.. for Ireland. Starting Virginia AT 1,000,000,000,000
---    means native Virginia orgs occupy the '001' sub-block. Orgs created
---    in Virginia's OWN region during normal operation carry prefix '001'.
--- ---------------------------------------------------------------------
-CREATE SEQUENCE IF NOT EXISTS virginia_dev_saayam_rdbms.seq_org_id
-    START WITH 1000000000000
-    INCREMENT BY 1
-    NO MAXVALUE
-    NO CYCLE;
+CREATE SEQUENCE IF NOT EXISTS virginia_dev_saayam_rdbms.org_id_seq
+    START WITH 1 INCREMENT BY 1 MINVALUE 1 MAXVALUE 999999999999 NO CYCLE;
 
-
--- ---------------------------------------------------------------------
--- 2. Generator function (hardcoded prefix '001' for Virginia)
---    Output example: ORG-00-001-004-010-003
---    Layout: ORG-00-<region:3>-<seg1:3>-<seg2:3>-<seg3:3>
---    Divisor math is billion-scale to support trillion ranges:
---      seg1 = (seq % 1,000,000,000) / 1,000,000
---      seg2 = (seq % 1,000,000)     / 1,000
---      seg3 =  seq % 1,000
--- ---------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION virginia_dev_saayam_rdbms.generate_org_id()
 RETURNS TRIGGER AS $$
 DECLARE
     seq_id BIGINT;
-    new_id TEXT;
-    region_prefix TEXT := '001';   -- [D3] hardcoded: Virginia
+    padded TEXT;
 BEGIN
-    -- Only generate if caller did not supply an org_id explicitly.
-    IF (NEW.org_id IS NULL) THEN
-        seq_id := nextval('virginia_dev_saayam_rdbms.seq_org_id');
-
-        new_id := 'ORG-00-' || region_prefix || '-' ||
-                  LPAD(FLOOR((seq_id % 1000000000) / 1000000)::TEXT, 3, '0') || '-' ||
-                  LPAD(FLOOR((seq_id % 1000000) / 1000)::TEXT, 3, '0') || '-' ||
-                  LPAD((seq_id % 1000)::TEXT, 3, '0');
-
-        NEW.org_id := new_id;
+    IF NEW.org_id IS NOT NULL THEN            -- replication / DR copy-back -> keep id
+        RETURN NEW;
     END IF;
 
+    seq_id := nextval('virginia_dev_saayam_rdbms.org_id_seq');
+    padded := LPAD(seq_id::TEXT, 13, '0');
+
+    IF length(padded) > 13 THEN               -- SUBSTRING width contract
+        RAISE EXCEPTION 'org_id_seq value % exceeds 13 digits; format would corrupt', seq_id;
+    END IF;
+
+    NEW.org_id := 'ORG-' ||
+        SUBSTRING(padded FROM 1  FOR 3) || '-' ||
+        SUBSTRING(padded FROM 4  FOR 3) || '-' ||
+        SUBSTRING(padded FROM 7  FOR 3) || '-' ||
+        SUBSTRING(padded FROM 10 FOR 4);
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 
-
--- ---------------------------------------------------------------------
--- 3. Trigger: fire before INSERT on organizations.
---    [D1] Assumes table virginia_dev_saayam_rdbms.organizations with
---         column org_id as PK.
--- ---------------------------------------------------------------------
-CREATE TRIGGER trg_generate_org_id
+CREATE OR REPLACE TRIGGER before_insert_organizations
     BEFORE INSERT ON virginia_dev_saayam_rdbms.organizations
     FOR EACH ROW EXECUTE FUNCTION virginia_dev_saayam_rdbms.generate_org_id();

--- a/script-library/tests/test_org_seq_virginia.sql
+++ b/script-library/tests/test_org_seq_virginia.sql
@@ -1,0 +1,49 @@
+DO $$
+DECLARE
+    v_id1 TEXT;
+    v_id2 TEXT;
+BEGIN
+    RAISE NOTICE '=== VIRGINIA ORG ID GENERATOR TEST ===';
+
+    -- 1. Auto-generate on insert (org_id left NULL)
+    INSERT INTO virginia_dev_saayam_rdbms.organizations (org_name)
+    VALUES ('Test Org Alpha')
+    RETURNING org_id INTO v_id1;
+    RAISE NOTICE 'Generated id #1: %', v_id1;
+
+    INSERT INTO virginia_dev_saayam_rdbms.organizations (org_name)
+    VALUES ('Test Org Beta')
+    RETURNING org_id INTO v_id2;
+    RAISE NOTICE 'Generated id #2: %', v_id2;
+
+    -- 2. Format check: must start with ORG-00-001-
+    IF v_id1 LIKE 'ORG-00-001-%' THEN
+        RAISE NOTICE 'PASS: Virginia prefix ORG-00-001- present';
+    ELSE
+        RAISE EXCEPTION 'FAIL: unexpected prefix on %', v_id1;
+    END IF;
+
+    -- 3. Uniqueness / monotonicity
+    IF v_id1 <> v_id2 THEN
+        RAISE NOTICE 'PASS: consecutive ids differ';
+    ELSE
+        RAISE EXCEPTION 'FAIL: duplicate ids generated';
+    END IF;
+
+    -- 4. Explicit org_id must be respected (not overwritten)
+    INSERT INTO virginia_dev_saayam_rdbms.organizations (org_id, org_name)
+    VALUES ('ORG-00-999-000-000-001', 'Explicit Org');
+    PERFORM 1 FROM virginia_dev_saayam_rdbms.organizations
+        WHERE org_id = 'ORG-00-999-000-000-001';
+    IF FOUND THEN
+        RAISE NOTICE 'PASS: explicit org_id preserved';
+    ELSE
+        RAISE EXCEPTION 'FAIL: explicit org_id was overwritten';
+    END IF;
+
+    -- cleanup
+    DELETE FROM virginia_dev_saayam_rdbms.organizations
+    WHERE org_id IN (v_id1, v_id2, 'ORG-00-999-000-000-001');
+
+    RAISE NOTICE '=== ALL VIRGINIA TESTS PASSED ===';
+END $$;

--- a/script-library/tests/test_org_seq_virginia.sql
+++ b/script-library/tests/test_org_seq_virginia.sql
@@ -1,49 +1,67 @@
+-- ============================================================================
+--  test_organizations_virginia.sql   —  run in the VIRGINIA database
+--  Verifies the updated generator (ORG-XXX-XXX-XXX-XXXX, 000-band).
+--  Assertions print via RAISE NOTICE (psql output / pgAdmin "Messages" tab).
+--  setval/TRUNCATE make it repeatable — TEST DATABASE ONLY.
+-- ============================================================================
+
+TRUNCATE virginia_dev_saayam_rdbms.organizations;
+SELECT setval('virginia_dev_saayam_rdbms.org_id_seq', 1, false);   -- next = 1
+
+-- T1  Sequential mint in the 000-band ---------------------------------------
 DO $$
-DECLARE
-    v_id1 TEXT;
-    v_id2 TEXT;
+DECLARE a TEXT; b TEXT;
 BEGIN
-    RAISE NOTICE '=== VIRGINIA ORG ID GENERATOR TEST ===';
+    INSERT INTO virginia_dev_saayam_rdbms.organizations(org_name) VALUES ('VA-1') RETURNING org_id INTO a;
+    INSERT INTO virginia_dev_saayam_rdbms.organizations(org_name) VALUES ('VA-2') RETURNING org_id INTO b;
+    IF a='ORG-000-000-000-0001' AND b='ORG-000-000-000-0002'
+        THEN RAISE NOTICE 'T1 PASS  Virginia sequential 000-band (%, %)', a, b;
+        ELSE RAISE NOTICE 'T1 FAIL  got %, %', a, b; END IF;
+END$$;
 
-    -- 1. Auto-generate on insert (org_id left NULL)
-    INSERT INTO virginia_dev_saayam_rdbms.organizations (org_name)
-    VALUES ('Test Org Alpha')
-    RETURNING org_id INTO v_id1;
-    RAISE NOTICE 'Generated id #1: %', v_id1;
+-- T2  Trust-hook: a pre-supplied id (replica / DR copy-back) is kept, and the
+--     local sequence is NOT consumed -----------------------------------------
+DO $$
+DECLARE kept TEXT; nxt TEXT;
+BEGIN
+    PERFORM setval('virginia_dev_saayam_rdbms.org_id_seq', 50, true);   -- next mint = 51
+    INSERT INTO virginia_dev_saayam_rdbms.organizations(org_id, org_name)
+        VALUES ('ORG-100-000-000-0000', 'copied-from-ireland') RETURNING org_id INTO kept;
+    INSERT INTO virginia_dev_saayam_rdbms.organizations(org_name)
+        VALUES ('next-local') RETURNING org_id INTO nxt;
+    IF kept='ORG-100-000-000-0000' AND nxt='ORG-000-000-000-0051'
+        THEN RAISE NOTICE 'T2 PASS  pre-supplied id kept (%), sequence not consumed (next=%)', kept, nxt;
+        ELSE RAISE NOTICE 'T2 FAIL  kept=% next=%', kept, nxt; END IF;
+END$$;
 
-    INSERT INTO virginia_dev_saayam_rdbms.organizations (org_name)
-    VALUES ('Test Org Beta')
-    RETURNING org_id INTO v_id2;
-    RAISE NOTICE 'Generated id #2: %', v_id2;
+-- T3  Segment-rollover math at 1,000 / 10,000 / 1,000,000 -------------------
+DO $$
+DECLARE a TEXT; b TEXT; c TEXT;
+BEGIN
+    PERFORM setval('virginia_dev_saayam_rdbms.org_id_seq', 999, true);
+    INSERT INTO virginia_dev_saayam_rdbms.organizations(org_name) VALUES ('r1k')  RETURNING org_id INTO a;
+    PERFORM setval('virginia_dev_saayam_rdbms.org_id_seq', 9999, true);
+    INSERT INTO virginia_dev_saayam_rdbms.organizations(org_name) VALUES ('r10k') RETURNING org_id INTO b;
+    PERFORM setval('virginia_dev_saayam_rdbms.org_id_seq', 999999, true);
+    INSERT INTO virginia_dev_saayam_rdbms.organizations(org_name) VALUES ('r1m')  RETURNING org_id INTO c;
+    IF a='ORG-000-000-000-1000' AND b='ORG-000-000-001-0000' AND c='ORG-000-000-100-0000'
+        THEN RAISE NOTICE 'T3 PASS  rollover correct (%, %, %)', a, b, c;
+        ELSE RAISE NOTICE 'T3 FAIL  got %, %, %', a, b, c; END IF;
+END$$;
 
-    -- 2. Format check: must start with ORG-00-001-
-    IF v_id1 LIKE 'ORG-00-001-%' THEN
-        RAISE NOTICE 'PASS: Virginia prefix ORG-00-001- present';
-    ELSE
-        RAISE EXCEPTION 'FAIL: unexpected prefix on %', v_id1;
-    END IF;
+-- T4  Exhaustion hard wall at MAXVALUE 999,999,999,999 ----------------------
+DO $$
+DECLARE last_id TEXT;
+BEGIN
+    PERFORM setval('virginia_dev_saayam_rdbms.org_id_seq', 999999999998, true);   -- next = MAXVALUE
+    INSERT INTO virginia_dev_saayam_rdbms.organizations(org_name) VALUES ('last') RETURNING org_id INTO last_id;
+    RAISE NOTICE 'T4 ..  last mint at MAXVALUE = %', last_id;
+    BEGIN
+        INSERT INTO virginia_dev_saayam_rdbms.organizations(org_name) VALUES ('over');
+        RAISE NOTICE 'T4 FAIL  sequence did not exhaust';
+    EXCEPTION WHEN others THEN
+        RAISE NOTICE 'T4 PASS  hard wall hit as designed: %', SQLERRM;
+    END;
+END$$;
 
-    -- 3. Uniqueness / monotonicity
-    IF v_id1 <> v_id2 THEN
-        RAISE NOTICE 'PASS: consecutive ids differ';
-    ELSE
-        RAISE EXCEPTION 'FAIL: duplicate ids generated';
-    END IF;
-
-    -- 4. Explicit org_id must be respected (not overwritten)
-    INSERT INTO virginia_dev_saayam_rdbms.organizations (org_id, org_name)
-    VALUES ('ORG-00-999-000-000-001', 'Explicit Org');
-    PERFORM 1 FROM virginia_dev_saayam_rdbms.organizations
-        WHERE org_id = 'ORG-00-999-000-000-001';
-    IF FOUND THEN
-        RAISE NOTICE 'PASS: explicit org_id preserved';
-    ELSE
-        RAISE EXCEPTION 'FAIL: explicit org_id was overwritten';
-    END IF;
-
-    -- cleanup
-    DELETE FROM virginia_dev_saayam_rdbms.organizations
-    WHERE org_id IN (v_id1, v_id2, 'ORG-00-999-000-000-001');
-
-    RAISE NOTICE '=== ALL VIRGINIA TESTS PASSED ===';
-END $$;
+SELECT org_id, org_name FROM virginia_dev_saayam_rdbms.organizations ORDER BY org_id;

--- a/script-library/tests/test_orq_seq_ireland.sql
+++ b/script-library/tests/test_orq_seq_ireland.sql
@@ -1,43 +1,65 @@
+-- ============================================================================
+--  test_organizations_ireland.sql   —  run in the IRELAND database
+--  Verifies the updated DR generator (ORG-XXX-XXX-XXX-XXXX, 100-band).
+--  Ireland = DR for Virginia; its sequence lives in the 1,000,000,000,000 band.
+--  Assertions print via RAISE NOTICE. setval/TRUNCATE => TEST DATABASE ONLY.
+-- ============================================================================
+
+TRUNCATE ireland_dev_saayam_rdbms.organizations;
+SELECT setval('ireland_dev_saayam_rdbms.org_id_dr_seq', 1000000000000, false);   -- next = 1e12
+
+-- T1  Sequential mint in the 100-band ---------------------------------------
 DO $$
-DECLARE
-    v_id1 TEXT;
-    v_id2 TEXT;
+DECLARE a TEXT; b TEXT;
 BEGIN
-    RAISE NOTICE '=== IRELAND ORG ID GENERATOR TEST ===';
+    INSERT INTO ireland_dev_saayam_rdbms.organizations(org_name) VALUES ('IE-1') RETURNING org_id INTO a;
+    INSERT INTO ireland_dev_saayam_rdbms.organizations(org_name) VALUES ('IE-2') RETURNING org_id INTO b;
+    IF a='ORG-100-000-000-0000' AND b='ORG-100-000-000-0001'
+        THEN RAISE NOTICE 'T1 PASS  Ireland-DR sequential 100-band (%, %)', a, b;
+        ELSE RAISE NOTICE 'T1 FAIL  got %, %', a, b; END IF;
+END$$;
 
-    INSERT INTO ireland_dev_saayam_rdbms.organizations (org_name)
-    VALUES ('Test Org Gamma')
-    RETURNING org_id INTO v_id1;
-    RAISE NOTICE 'Generated id #1: %', v_id1;
+-- T2  Trust-hook: a pre-supplied id (e.g. a Virginia 000-band id being
+--     replicated in) is kept, and the DR sequence is NOT consumed -----------
+DO $$
+DECLARE kept TEXT; nxt TEXT;
+BEGIN
+    PERFORM setval('ireland_dev_saayam_rdbms.org_id_dr_seq', 1000000000050, true);  -- next = ...051
+    INSERT INTO ireland_dev_saayam_rdbms.organizations(org_id, org_name)
+        VALUES ('ORG-000-000-000-0007', 'replicated-from-virginia') RETURNING org_id INTO kept;
+    INSERT INTO ireland_dev_saayam_rdbms.organizations(org_name)
+        VALUES ('next-dr') RETURNING org_id INTO nxt;
+    IF kept='ORG-000-000-000-0007' AND nxt='ORG-100-000-000-0051'
+        THEN RAISE NOTICE 'T2 PASS  pre-supplied id kept (%), DR seq not consumed (next=%)', kept, nxt;
+        ELSE RAISE NOTICE 'T2 FAIL  kept=% next=%', kept, nxt; END IF;
+END$$;
 
-    INSERT INTO ireland_dev_saayam_rdbms.organizations (org_name)
-    VALUES ('Test Org Delta')
-    RETURNING org_id INTO v_id2;
-    RAISE NOTICE 'Generated id #2: %', v_id2;
+-- T3  Segment-rollover math inside the 100-band -----------------------------
+DO $$
+DECLARE a TEXT; b TEXT;
+BEGIN
+    PERFORM setval('ireland_dev_saayam_rdbms.org_id_dr_seq', 1000000000999, true);  -- next ...1000
+    INSERT INTO ireland_dev_saayam_rdbms.organizations(org_name) VALUES ('r1k')  RETURNING org_id INTO a;
+    PERFORM setval('ireland_dev_saayam_rdbms.org_id_dr_seq', 1000000009999, true);  -- next ...10000
+    INSERT INTO ireland_dev_saayam_rdbms.organizations(org_name) VALUES ('r10k') RETURNING org_id INTO b;
+    IF a='ORG-100-000-000-1000' AND b='ORG-100-000-001-0000'
+        THEN RAISE NOTICE 'T3 PASS  rollover correct (%, %)', a, b;
+        ELSE RAISE NOTICE 'T3 FAIL  got %, %', a, b; END IF;
+END$$;
 
-    -- Format check: must start with ORG-00-002-
-    IF v_id1 LIKE 'ORG-00-002-%' THEN
-        RAISE NOTICE 'PASS: Ireland prefix ORG-00-002- present';
-    ELSE
-        RAISE EXCEPTION 'FAIL: unexpected prefix on %', v_id1;
-    END IF;
+-- T4  Exhaustion hard wall at MAXVALUE 1,999,999,999,999 --------------------
+DO $$
+DECLARE last_id TEXT;
+BEGIN
+    PERFORM setval('ireland_dev_saayam_rdbms.org_id_dr_seq', 1999999999998, true); -- next = MAXVALUE
+    INSERT INTO ireland_dev_saayam_rdbms.organizations(org_name) VALUES ('last') RETURNING org_id INTO last_id;
+    RAISE NOTICE 'T4 ..  last mint at MAXVALUE = %', last_id;
+    BEGIN
+        INSERT INTO ireland_dev_saayam_rdbms.organizations(org_name) VALUES ('over');
+        RAISE NOTICE 'T4 FAIL  sequence did not exhaust';
+    EXCEPTION WHEN others THEN
+        RAISE NOTICE 'T4 PASS  hard wall hit as designed: %', SQLERRM;
+    END;
+END$$;
 
-    -- Cross-region collision guard: Ireland ids must NOT carry the
-    -- Virginia 001 prefix.
-    IF v_id1 NOT LIKE 'ORG-00-001-%' THEN
-        RAISE NOTICE 'PASS: Ireland id does not collide with Virginia range';
-    ELSE
-        RAISE EXCEPTION 'FAIL: Ireland produced a Virginia-range id';
-    END IF;
-
-    IF v_id1 <> v_id2 THEN
-        RAISE NOTICE 'PASS: consecutive ids differ';
-    ELSE
-        RAISE EXCEPTION 'FAIL: duplicate ids generated';
-    END IF;
-
-    DELETE FROM ireland_dev_saayam_rdbms.organizations
-    WHERE org_id IN (v_id1, v_id2);
-
-    RAISE NOTICE '=== ALL IRELAND TESTS PASSED ===';
-END $$;
+SELECT org_id, org_name FROM ireland_dev_saayam_rdbms.organizations ORDER BY org_id;

--- a/script-library/tests/test_orq_seq_ireland.sql
+++ b/script-library/tests/test_orq_seq_ireland.sql
@@ -1,0 +1,43 @@
+DO $$
+DECLARE
+    v_id1 TEXT;
+    v_id2 TEXT;
+BEGIN
+    RAISE NOTICE '=== IRELAND ORG ID GENERATOR TEST ===';
+
+    INSERT INTO ireland_dev_saayam_rdbms.organizations (org_name)
+    VALUES ('Test Org Gamma')
+    RETURNING org_id INTO v_id1;
+    RAISE NOTICE 'Generated id #1: %', v_id1;
+
+    INSERT INTO ireland_dev_saayam_rdbms.organizations (org_name)
+    VALUES ('Test Org Delta')
+    RETURNING org_id INTO v_id2;
+    RAISE NOTICE 'Generated id #2: %', v_id2;
+
+    -- Format check: must start with ORG-00-002-
+    IF v_id1 LIKE 'ORG-00-002-%' THEN
+        RAISE NOTICE 'PASS: Ireland prefix ORG-00-002- present';
+    ELSE
+        RAISE EXCEPTION 'FAIL: unexpected prefix on %', v_id1;
+    END IF;
+
+    -- Cross-region collision guard: Ireland ids must NOT carry the
+    -- Virginia 001 prefix.
+    IF v_id1 NOT LIKE 'ORG-00-001-%' THEN
+        RAISE NOTICE 'PASS: Ireland id does not collide with Virginia range';
+    ELSE
+        RAISE EXCEPTION 'FAIL: Ireland produced a Virginia-range id';
+    END IF;
+
+    IF v_id1 <> v_id2 THEN
+        RAISE NOTICE 'PASS: consecutive ids differ';
+    ELSE
+        RAISE EXCEPTION 'FAIL: duplicate ids generated';
+    END IF;
+
+    DELETE FROM ireland_dev_saayam_rdbms.organizations
+    WHERE org_id IN (v_id1, v_id2);
+
+    RAISE NOTICE '=== ALL IRELAND TESTS PASSED ===';
+END $$;


### PR DESCRIPTION
Virginia (ddl_organizations_virginia.sql)

Gives the Virginia organizations table an automatic ID generator that fires whenever a new organization is inserted without an ID
Produces IDs shaped like ORG-00-001-XXX-XXX-XXX, where ORG marks an organization ID, 00 is a fixed namespace marker, 001 is the hardcoded Virginia region sub-block, and the trailing three groups come from a running counter
Works through three objects: a sequence handing out increasing numbers starting at one trillion, a function that slices the next number into three-digit groups and adds the prefix, and a trigger that runs the function automatically before every insert
Starts the sequence at one trillion specifically to prevent disaster-recovery collisions — if Virginia and Ireland both counted from low numbers, they could mint the same ID and corrupt the primary key on sync-back
Has no EU/non-EU split, because the ADR classifies organizations as global operational tables, not region-sensitive PII

Ireland (ddl_organizations_ireland.sql)

Does the same job as Virginia, producing ORG-00-002-XXX-XXX-XXX identifiers
Differs from Virginia in only two values: the sequence starts at two trillion instead of one, and the region sub-block is 002 instead of 001
Those two differences are the entire collision-avoidance mechanism — separate ranges mean the regions can never generate the same ID, even during failover
Has no EU/non-EU dual path, since an organization record holds no personal data needing in-region storage

The Two DDL Change-Scripts
Virginia and Ireland (alter_org_seq_virginia.sql, alter_org_seq_ireland.sql)

Migration versions of the create-scripts, for when the organizations table already exists and you only need to add or refresh the generator without recreating the table
Are idempotent — safe to run more than once with the same end result
Achieve that three ways: the sequence is created only if missing (so re-running never resets the counter or breaks ID continuity), the function is replaced in place, and the trigger is dropped if present before being recreated (so a second run won't error)
Each carries a commented-out rollback block that drops the trigger, function, and sequence in the correct dependency order
The Virginia change-script adds a note on how to convert to the alternative four-segment STD- format if the team chooses it later