### PR TITLE
feat: Virginia schema alterations — column renames, type changes, trigger updates per issue #246

### DIFF
--- a/ddl/ddl_changes/ddl_update_#246.sql
+++ b/ddl/ddl_changes/ddl_update_#246.sql
@@ -1,0 +1,249 @@
+BEGIN;
+
+-- =============================================
+-- 0. action
+-- =============================================
+ALTER TABLE virginia_dev_saayam_rdbms.action
+    RENAME COLUMN created_date TO created_at;
+
+ALTER TABLE virginia_dev_saayam_rdbms.action
+    RENAME COLUMN last_update_date TO last_updated_at;
+
+ALTER TABLE virginia_dev_saayam_rdbms.action
+    ALTER COLUMN created_at SET DEFAULT (now() AT TIME ZONE 'UTC'),
+    ALTER COLUMN last_updated_at SET DEFAULT (now() AT TIME ZONE 'UTC');
+
+CREATE TRIGGER trg_action_updated_at
+BEFORE UPDATE ON virginia_dev_saayam_rdbms.action
+FOR EACH ROW
+EXECUTE FUNCTION virginia_dev_saayam_rdbms.set_updated_at();
+
+-- =============================================
+-- 1. country
+-- =============================================
+ALTER TABLE virginia_dev_saayam_rdbms.country
+    RENAME COLUMN last_update_date TO last_updated_at;
+
+ALTER TABLE virginia_dev_saayam_rdbms.country
+    ALTER COLUMN last_updated_at SET DEFAULT (now() AT TIME ZONE 'UTC');
+
+CREATE TRIGGER trg_country_updated_at
+BEFORE UPDATE ON virginia_dev_saayam_rdbms.country
+FOR EACH ROW
+EXECUTE FUNCTION virginia_dev_saayam_rdbms.set_updated_at();
+
+-- =============================================
+-- 2. identity_type
+-- =============================================
+ALTER TABLE virginia_dev_saayam_rdbms.identity_type
+    RENAME COLUMN identity_type_dsc TO identity_type_desc;
+
+ALTER TABLE virginia_dev_saayam_rdbms.identity_type
+    RENAME COLUMN last_updated_date TO last_updated_at;
+
+ALTER TABLE virginia_dev_saayam_rdbms.identity_type
+    ALTER COLUMN last_updated_at SET DEFAULT (now() AT TIME ZONE 'UTC');
+
+CREATE TRIGGER trg_identity_type_updated_at
+BEFORE UPDATE ON virginia_dev_saayam_rdbms.identity_type
+FOR EACH ROW
+EXECUTE FUNCTION virginia_dev_saayam_rdbms.set_updated_at();
+
+-- =============================================
+-- 3. request_priority
+-- =============================================
+ALTER TABLE virginia_dev_saayam_rdbms.request_priority
+    RENAME COLUMN last_updated_date TO last_updated_at;
+
+ALTER TABLE virginia_dev_saayam_rdbms.request_priority
+    ALTER COLUMN last_updated_at SET DEFAULT (now() AT TIME ZONE 'UTC');
+
+CREATE TRIGGER trg_request_priority_updated_at
+BEFORE UPDATE ON virginia_dev_saayam_rdbms.request_priority
+FOR EACH ROW
+EXECUTE FUNCTION virginia_dev_saayam_rdbms.set_updated_at();
+
+-- =============================================
+-- 4. user_status
+-- =============================================
+ALTER TABLE virginia_dev_saayam_rdbms.user_status
+    RENAME COLUMN last_update_date TO last_updated_at;
+
+ALTER TABLE virginia_dev_saayam_rdbms.user_status
+    ALTER COLUMN last_updated_at SET DEFAULT (now() AT TIME ZONE 'UTC');
+
+CREATE TRIGGER trg_user_status_updated_at
+BEFORE UPDATE ON virginia_dev_saayam_rdbms.user_status
+FOR EACH ROW
+EXECUTE FUNCTION virginia_dev_saayam_rdbms.set_updated_at();
+
+-- =============================================
+-- 5. user_category
+-- =============================================
+ALTER TABLE virginia_dev_saayam_rdbms.user_category
+    ALTER COLUMN last_updated_at TYPE TIMESTAMP WITHOUT TIME ZONE,
+    ALTER COLUMN last_updated_at SET DEFAULT (now() AT TIME ZONE 'UTC');
+
+CREATE TRIGGER trg_user_category_updated_at
+BEFORE UPDATE ON virginia_dev_saayam_rdbms.user_category
+FOR EACH ROW
+EXECUTE FUNCTION virginia_dev_saayam_rdbms.set_updated_at();
+
+-- =============================================
+-- 6. state
+-- =============================================
+ALTER TABLE virginia_dev_saayam_rdbms.state
+    RENAME COLUMN last_update_date TO last_updated_at;
+
+ALTER TABLE virginia_dev_saayam_rdbms.state
+    ALTER COLUMN last_updated_at SET DEFAULT (now() AT TIME ZONE 'UTC');
+
+CREATE TRIGGER trg_state_updated_at
+BEFORE UPDATE ON virginia_dev_saayam_rdbms.state
+FOR EACH ROW
+EXECUTE FUNCTION virginia_dev_saayam_rdbms.set_updated_at();
+
+-- =============================================
+-- 7. city
+-- =============================================
+ALTER TABLE virginia_dev_saayam_rdbms.city
+    RENAME COLUMN last_update_date TO last_updated_at;
+
+ALTER TABLE virginia_dev_saayam_rdbms.city
+    ALTER COLUMN last_updated_at SET DEFAULT (now() AT TIME ZONE 'UTC');
+
+-- Change state_id type from INT to VARCHAR(50)
+ALTER TABLE virginia_dev_saayam_rdbms.city
+    DROP CONSTRAINT IF EXISTS city_state_id_fkey;
+
+ALTER TABLE virginia_dev_saayam_rdbms.city
+    ALTER COLUMN state_id TYPE VARCHAR(50);
+
+ALTER TABLE virginia_dev_saayam_rdbms.city
+    ADD CONSTRAINT city_state_id_fkey
+    FOREIGN KEY (state_id) REFERENCES virginia_dev_saayam_rdbms.state (state_id);
+
+CREATE TRIGGER trg_city_updated_at
+BEFORE UPDATE ON virginia_dev_saayam_rdbms.city
+FOR EACH ROW
+EXECUTE FUNCTION virginia_dev_saayam_rdbms.set_updated_at();
+
+-- =============================================
+-- 8. supporting_languages
+-- =============================================
+ALTER TABLE virginia_dev_saayam_rdbms.supporting_languages
+    RENAME COLUMN iso_639_1_code TO iso_code;
+
+ALTER TABLE virginia_dev_saayam_rdbms.supporting_languages
+    ALTER COLUMN created_at TYPE TIMESTAMP WITHOUT TIME ZONE,
+    ALTER COLUMN created_at SET DEFAULT (now() AT TIME ZONE 'UTC'),
+    ALTER COLUMN last_updated_at TYPE TIMESTAMP WITHOUT TIME ZONE,
+    ALTER COLUMN last_updated_at SET DEFAULT (now() AT TIME ZONE 'UTC');
+
+-- Drop old unqualified trigger and recreate with schema
+DROP TRIGGER IF EXISTS trg_supporting_lang_updated_at
+    ON virginia_dev_saayam_rdbms.supporting_languages;
+
+CREATE TRIGGER trg_supporting_lang_updated_at
+BEFORE UPDATE ON virginia_dev_saayam_rdbms.supporting_languages
+FOR EACH ROW
+EXECUTE FUNCTION virginia_dev_saayam_rdbms.set_updated_at();
+
+-- =============================================
+-- 9. users
+-- =============================================
+
+-- Rename timestamp columns
+ALTER TABLE virginia_dev_saayam_rdbms.users
+    RENAME COLUMN last_update_date TO last_updated_at;
+
+ALTER TABLE virginia_dev_saayam_rdbms.users
+    RENAME COLUMN promotion_wizard_last_update_date TO promotion_wizard_last_updated_at;
+
+-- Set defaults
+ALTER TABLE virginia_dev_saayam_rdbms.users
+    ALTER COLUMN last_updated_at SET DEFAULT (now() AT TIME ZONE 'UTC'),
+    ALTER COLUMN promotion_wizard_last_updated_at SET DEFAULT (now() AT TIME ZONE 'UTC');
+
+-- Comment out user_category_id foreign key
+ALTER TABLE virginia_dev_saayam_rdbms.users
+    DROP CONSTRAINT IF EXISTS users_user_category_id_fkey;
+
+ALTER TABLE virginia_dev_saayam_rdbms.users
+    DROP COLUMN IF EXISTS user_category_id;
+
+-- Change language columns from VARCHAR to BIGINT
+ALTER TABLE virginia_dev_saayam_rdbms.users
+    ALTER COLUMN language_1 TYPE BIGINT USING language_1::BIGINT,
+    ALTER COLUMN language_2 TYPE BIGINT USING language_2::BIGINT,
+    ALTER COLUMN language_3 TYPE BIGINT USING language_3::BIGINT;
+
+-- Add foreign keys for language columns
+ALTER TABLE virginia_dev_saayam_rdbms.users
+    ADD CONSTRAINT users_language_1_fkey
+    FOREIGN KEY (language_1) REFERENCES virginia_dev_saayam_rdbms.supporting_languages(language_id) ON DELETE SET NULL,
+    ADD CONSTRAINT users_language_2_fkey
+    FOREIGN KEY (language_2) REFERENCES virginia_dev_saayam_rdbms.supporting_languages(language_id) ON DELETE SET NULL,
+    ADD CONSTRAINT users_language_3_fkey
+    FOREIGN KEY (language_3) REFERENCES virginia_dev_saayam_rdbms.supporting_languages(language_id) ON DELETE SET NULL;
+
+-- Add new columns
+ALTER TABLE virginia_dev_saayam_rdbms.users
+    ADD COLUMN IF NOT EXISTS external_auth_provider VARCHAR(20) NULL,
+    ADD COLUMN IF NOT EXISTS dob DATE,
+    ADD COLUMN IF NOT EXISTS is_eu BOOLEAN DEFAULT FALSE;
+
+-- Add triggers
+CREATE OR REPLACE FUNCTION virginia_dev_saayam_rdbms.set_promo_wizard_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF (NEW.promotion_wizard_last_updated_at IS DISTINCT FROM OLD.promotion_wizard_last_updated_at)
+    THEN NEW.promotion_wizard_last_updated_at = (NOW() AT TIME ZONE 'UTC');
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_users_updated_at
+BEFORE UPDATE ON virginia_dev_saayam_rdbms.users
+FOR EACH ROW
+EXECUTE FUNCTION virginia_dev_saayam_rdbms.set_updated_at();
+
+CREATE TRIGGER trg_users_promo_wizard_updated_at
+BEFORE UPDATE ON virginia_dev_saayam_rdbms.users
+FOR EACH ROW
+EXECUTE FUNCTION virginia_dev_saayam_rdbms.set_promo_wizard_updated_at();
+
+-- Update sequence
+ALTER SEQUENCE virginia_dev_saayam_rdbms.user_id_seq
+    RENAME TO user_id_seq_old;
+
+CREATE SEQUENCE virginia_dev_saayam_rdbms.user_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    MINVALUE 1
+    MAXVALUE 19999999999
+    NO CYCLE;
+
+-- Replace generate_sid()
+CREATE OR REPLACE FUNCTION virginia_dev_saayam_rdbms.generate_sid()
+RETURNS TRIGGER AS $$
+DECLARE
+    seq_id BIGINT;
+    padded TEXT;
+BEGIN
+    seq_id := nextval('virginia_dev_saayam_rdbms.user_id_seq');
+    padded := LPAD(seq_id::TEXT, 15, '0');
+    NEW.user_id := 'SID-00-' ||
+        SUBSTRING(padded FROM 1 FOR 3) || '-' ||
+        SUBSTRING(padded FROM 4 FOR 3) || '-' ||
+        SUBSTRING(padded FROM 7 FOR 3) || '-' ||
+        SUBSTRING(padded FROM 10 FOR 3) || '-' ||
+        SUBSTRING(padded FROM 13 FOR 3);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP SEQUENCE IF EXISTS virginia_dev_saayam_rdbms.user_id_seq_old;
+
+COMMIT;

--- a/script-library/tests/test_ddl_update_#246.sql
+++ b/script-library/tests/test_ddl_update_#246.sql
@@ -1,0 +1,179 @@
+BEGIN;
+
+SELECT plan(30);
+
+-- =============================================
+-- 0. action
+-- =============================================
+SELECT has_column(
+    'virginia_dev_saayam_rdbms', 'action', 'created_at',
+    'action: created_at column exists'
+);
+
+SELECT has_column(
+    'virginia_dev_saayam_rdbms', 'action', 'last_updated_at',
+    'action: last_updated_at column exists'
+);
+
+SELECT hasnt_column(
+    'virginia_dev_saayam_rdbms', 'action', 'created_date',
+    'action: created_date column removed'
+);
+
+SELECT hasnt_column(
+    'virginia_dev_saayam_rdbms', 'action', 'last_update_date',
+    'action: last_update_date column removed'
+);
+
+SELECT trigger_is(
+    'virginia_dev_saayam_rdbms', 'action', 'trg_action_updated_at',
+    'virginia_dev_saayam_rdbms', 'set_updated_at',
+    'action: trg_action_updated_at trigger exists'
+);
+
+-- =============================================
+-- 1. country
+-- =============================================
+SELECT has_column(
+    'virginia_dev_saayam_rdbms', 'country', 'last_updated_at',
+    'country: last_updated_at column exists'
+);
+
+SELECT hasnt_column(
+    'virginia_dev_saayam_rdbms', 'country', 'last_update_date',
+    'country: last_update_date column removed'
+);
+
+SELECT trigger_is(
+    'virginia_dev_saayam_rdbms', 'country', 'trg_country_updated_at',
+    'virginia_dev_saayam_rdbms', 'set_updated_at',
+    'country: trg_country_updated_at trigger exists'
+);
+
+-- =============================================
+-- 2. identity_type
+-- =============================================
+SELECT has_column(
+    'virginia_dev_saayam_rdbms', 'identity_type', 'identity_type_desc',
+    'identity_type: identity_type_desc column exists'
+);
+
+SELECT hasnt_column(
+    'virginia_dev_saayam_rdbms', 'identity_type', 'identity_type_dsc',
+    'identity_type: identity_type_dsc column removed'
+);
+
+SELECT has_column(
+    'virginia_dev_saayam_rdbms', 'identity_type', 'last_updated_at',
+    'identity_type: last_updated_at column exists'
+);
+
+-- =============================================
+-- 3. supporting_languages
+-- =============================================
+SELECT has_column(
+    'virginia_dev_saayam_rdbms', 'supporting_languages', 'iso_code',
+    'supporting_languages: iso_code column exists'
+);
+
+SELECT hasnt_column(
+    'virginia_dev_saayam_rdbms', 'supporting_languages', 'iso_639_1_code',
+    'supporting_languages: iso_639_1_code column removed'
+);
+
+SELECT trigger_is(
+    'virginia_dev_saayam_rdbms', 'supporting_languages', 'trg_supporting_lang_updated_at',
+    'virginia_dev_saayam_rdbms', 'set_updated_at',
+    'supporting_languages: trigger uses schema qualified function'
+);
+
+-- =============================================
+-- 4. city
+-- =============================================
+SELECT has_column(
+    'virginia_dev_saayam_rdbms', 'city', 'last_updated_at',
+    'city: last_updated_at column exists'
+);
+
+SELECT col_type_is(
+    'virginia_dev_saayam_rdbms', 'city', 'state_id', 'character varying(50)',
+    'city: state_id is VARCHAR(50)'
+);
+
+-- =============================================
+-- 5. users
+-- =============================================
+SELECT has_column(
+    'virginia_dev_saayam_rdbms', 'users', 'last_updated_at',
+    'users: last_updated_at column exists'
+);
+
+SELECT hasnt_column(
+    'virginia_dev_saayam_rdbms', 'users', 'last_update_date',
+    'users: last_update_date column removed'
+);
+
+SELECT has_column(
+    'virginia_dev_saayam_rdbms', 'users', 'promotion_wizard_last_updated_at',
+    'users: promotion_wizard_last_updated_at column exists'
+);
+
+SELECT hasnt_column(
+    'virginia_dev_saayam_rdbms', 'users', 'promotion_wizard_last_update_date',
+    'users: promotion_wizard_last_update_date column removed'
+);
+
+SELECT hasnt_column(
+    'virginia_dev_saayam_rdbms', 'users', 'user_category_id',
+    'users: user_category_id column removed'
+);
+
+SELECT col_type_is(
+    'virginia_dev_saayam_rdbms', 'users', 'language_1', 'bigint',
+    'users: language_1 is BIGINT'
+);
+
+SELECT col_type_is(
+    'virginia_dev_saayam_rdbms', 'users', 'language_2', 'bigint',
+    'users: language_2 is BIGINT'
+);
+
+SELECT col_type_is(
+    'virginia_dev_saayam_rdbms', 'users', 'language_3', 'bigint',
+    'users: language_3 is BIGINT'
+);
+
+SELECT has_column(
+    'virginia_dev_saayam_rdbms', 'users', 'external_auth_provider',
+    'users: external_auth_provider column exists'
+);
+
+SELECT has_column(
+    'virginia_dev_saayam_rdbms', 'users', 'dob',
+    'users: dob column exists'
+);
+
+SELECT has_column(
+    'virginia_dev_saayam_rdbms', 'users', 'is_eu',
+    'users: is_eu column exists'
+);
+
+SELECT trigger_is(
+    'virginia_dev_saayam_rdbms', 'users', 'trg_users_updated_at',
+    'virginia_dev_saayam_rdbms', 'set_updated_at',
+    'users: trg_users_updated_at trigger exists'
+);
+
+SELECT trigger_is(
+    'virginia_dev_saayam_rdbms', 'users', 'trg_users_promo_wizard_updated_at',
+    'virginia_dev_saayam_rdbms', 'set_promo_wizard_updated_at',
+    'users: trg_users_promo_wizard_updated_at trigger exists'
+);
+
+SELECT col_default_is(
+    'virginia_dev_saayam_rdbms', 'users', 'is_eu', 'false',
+    'users: is_eu defaults to false'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary

This PR implements the Virginia schema alterations documented in issue #246. Changes cover column renames for consistency, timestamp standardization to UTC, type corrections, new columns, and trigger additions across 9 tables.

---

## Changes Made

### 0. action
- `created_date` → `created_at`
- `last_update_date` → `last_updated_at`
- Added `trg_action_updated_at` trigger

### 1. country
- `last_update_date` → `last_updated_at`
- Added `trg_country_updated_at` trigger

### 2. identity_type
- `identity_type_dsc` → `identity_type_desc`
- `last_updated_date` → `last_updated_at`
- Added `trg_identity_type_updated_at` trigger

### 3. request_priority
- `last_updated_date` → `last_updated_at`
- Added `trg_request_priority_updated_at` trigger

### 4. user_status
- `last_update_date` → `last_updated_at`
- Added `trg_user_status_updated_at` trigger

### 5. user_category
- `last_updated_at` standardized to `TIMESTAMP WITHOUT TIME ZONE DEFAULT (now() AT TIME ZONE 'UTC')`
- Added `trg_user_category_updated_at` trigger

### 6. state
- `last_update_date` → `last_updated_at`
- Added `trg_state_updated_at` trigger

### 7. city
- `last_update_date` → `last_updated_at`
- `state_id` type changed from `INT` to `VARCHAR(50)` to match state table primary key
- Foreign key constraint re-added after type change
- Added `trg_city_updated_at` trigger

### 8. supporting_languages
- `iso_639_1_code` → `iso_code`
- `created_at` and `last_updated_at` standardized to `TIMESTAMP WITHOUT TIME ZONE`
- Trigger function reference updated to schema-qualified `virginia_dev_saayam_rdbms.set_updated_at`

### 9. users
- `last_update_date` → `last_updated_at`
- `promotion_wizard_last_update_date` → `promotion_wizard_last_updated_at`
- `user_category_id` column and foreign key removed (replaced by `user_category_map` table)
- `language_1`, `language_2`, `language_3` changed from `VARCHAR(255)` to `BIGINT`
- Foreign keys added for `language_1`, `language_2`, `language_3` → `supporting_languages`
- Added `external_auth_provider VARCHAR(20)` column
- Added `dob DATE` column
- Added `is_eu BOOLEAN DEFAULT FALSE` column
- Added `trg_users_updated_at` trigger
- Added `trg_users_promo_wizard_updated_at` trigger
- Added `set_promo_wizard_updated_at()` function
- Sequence updated to SUBSTRING approach, range 1 → 19,999,999,999
- `generate_sid()` updated to SUBSTRING approach generating `SID-00-XXX-XXX-XXX-XXX-XXX`

---

## Files Changed

| File | Purpose |
|------|---------|
| `ddl/ddl_changes/ddl_update_#246.sql` | Alter script for all 9 tables |
| `script-library/tests/test_ddl_update_#246.sql` | pgTAP tests verifying all alterations |

---

## Test Results
Files=1, Tests=30, 0 wallclock secs
Result: PASS

---

## Notes
- `set_updated_at()` function was already declared in the Virginia schema — not recreated
- All timestamp columns standardized to `TIMESTAMP WITHOUT TIME ZONE DEFAULT (now() AT TIME ZONE 'UTC')`
- `city.state_id` foreign key was dropped and re-added after type change to avoid constraint violation

Closes #246


